### PR TITLE
chore: update taker tier docs

### DIFF
--- a/guides/for-buyers/reputation.md
+++ b/guides/for-buyers/reputation.md
@@ -55,6 +55,8 @@ Your tier is determined by two factors:
 
 ### Lock Score Details
 
+The Lock Score is calculated starting from block 39294530 on Base.
+
 - New users start with no history and are placed in Peer Peasant ($100 cap)
 - Cancelling orders after 15 minutes increases your lock score
 - Completing orders dilutes your lock score over time

--- a/guides/for-buyers/reputation.md
+++ b/guides/for-buyers/reputation.md
@@ -21,17 +21,17 @@ P2P systems work best when participants are reliable. When a taker locks an orde
 
 Taker Tiers incentivize good behavior by rewarding consistent, reliable users with higher limits.
 
-Similar to other reputation system on other P2P platforms, except this is computed entirely from your onchain activity.
+Similar to other reputation systems on other P2P platforms, except this is computed entirely from your onchain activity.
 
 ## The Five Tiers
 
-| Tier | Volume Range | Per-Intent Cap | Cooldown |
-|------|--------------|----------------|----------|
-| Peer Peasant | $0 - $500 | $100 | 24 hours |
-| Peer | $500 - $2k | $250 | 12 hours |
-| Peer Plus | $2k - $10k | $1,000 | 6 hours |
-| Peer Pro | $10k - $25k | $2,500 | No cooldown |
-| Peer Platinum | $25k+ | $5,000 | No cooldown |
+| Tier | Volume Threshold | Per-Intent Cap | Cooldown |
+|------|------------------|----------------|----------|
+| Peer Peasant | $0 | $100 | 24 hours |
+| Peer | $500 | $250 | 12 hours |
+| Peer Plus | $2,000 | $1,000 | 6 hours |
+| Peer Pro | $10,000 | $2,500 | No cooldown |
+| Peer Platinum | $25,000 | $5,000 | No cooldown |
 
 ## Cooldown Periods
 
@@ -47,13 +47,33 @@ If you attempt to create an intent while your cooldown is still active, you'll r
 
 ## How Reputation is Calculated
 
-Your tier is determined by your **lock score** — a penalty score where lower is better. The Lock Score is calculated after block 39294530 on Base. 
+Your tier is determined by two factors:
+
+1. **Total Fulfilled Volume** — The cumulative USD value of orders you've successfully completed. This determines your base tier.
+
+2. **Lock Score** — A penalty score where lower is better. High lock scores can demote you to a lower tier.
+
+### Lock Score Details
 
 - New users start with no history and are placed in Peer Peasant ($100 cap)
 - Cancelling orders after 15 minutes increases your lock score
 - Completing orders dilutes your lock score over time
+- Lock score is calculated as: `lockScore / max(totalFulfilledVolume, $250)`
 
-Cancellations within 15 minutes don't count against you, we get that you might need to back out quickly if something's off.
+Cancellations within 15 minutes don't count against you — we get that you might need to back out quickly if something's off.
+
+### Lock Score Penalty Thresholds
+
+Your diluted lock score can demote you by up to 4 tiers:
+
+| Diluted Lock Score | Tier Penalty |
+|--------------------|--------------|
+| ≥ 50 | -1 tier |
+| ≥ 200 | -2 tiers |
+| ≥ 500 | -3 tiers |
+| ≥ 1000 | -4 tiers |
+
+For example, if your fulfilled volume qualifies you for Peer Plus but your diluted lock score is 200, you'd be demoted 2 tiers to Peer Peasant.
 
 ## Where to See Your Tier
 


### PR DESCRIPTION
Corrections made:

  1. Table header: Changed "Volume Range" to "Volume Threshold" — it's a minimum threshold, not a range
  2. Volume values: Fixed "$2k" → "$2,000" and "$10k" → "$10,000" for consistency
  3. Clarified tier calculation: Explained that tier is determined by two factors (fulfilled volume + lock
  score), not just lock score
  4. Added lock score formula: lockScore / max(totalFulfilledVolume, $250) — this is the actual dilution
  calculation
  5. Added penalty thresholds table: Shows the exact thresholds (50, 200, 500, 1000) that cause tier demotions
  6. Fixed grammar: "reputation system" → "reputation systems"
