### PR TITLE
Add polished brand kit page

### DIFF
--- a/brand-kit/index.md
+++ b/brand-kit/index.md
@@ -1,28 +1,11 @@
 ---
 id: brand-kit
 title: Brand Kit
+slug: /brand-kit-legacy
 ---
 
-## Logos
+import {Redirect} from '@docusaurus/router';
 
-<div className="brand-kit-logos">
-  <img src="/img/brand-kit/logos/peer-logo-colour.svg" alt="Peer logo (colour)" loading="lazy" width="2456" height="864" />
-  <img src="/img/brand-kit/logos/peer-logo-white.svg" alt="Peer logo (white)" loading="lazy" width="2456" height="864" />
-  <img src="/img/brand-kit/logos/peer-logo-black.svg" alt="Peer logo (black)" loading="lazy" width="2456" height="864" />
-  <img src="/img/brand-kit/logos/peer-profile.png" alt="Peer profile mark" loading="lazy" width="2000" height="2000" />
-</div>
+<Redirect to="/brand-kit" />
 
-**Logo variants**
-- [Peer logo — colour (SVG)](/img/brand-kit/logos/peer-logo-colour.svg)
-- [Peer logo — white (SVG)](/img/brand-kit/logos/peer-logo-white.svg)
-- [Peer logo — black (SVG)](/img/brand-kit/logos/peer-logo-black.svg)
-- [Peer logo — colour (PNG)](/img/brand-kit/logos/peer-logo-colour.png)
-- [Peer logo — white (PNG)](/img/brand-kit/logos/peer-logo-white.png)
-- [Peer logo — black (PNG)](/img/brand-kit/logos/peer-logo-black.png)
-- [Peer profile mark (PNG)](/img/brand-kit/logos/peer-profile.png)
-
-
-## Downloads
-
-- [Download all logos (ZIP)](/brand-kit/peer-logos.zip)
-- [Download full brand kit (Google Drive)](https://drive.google.com/drive/folders/1tztk4ikZGSVZTQWryuM-gKiQjiyIzLix?usp=sharing)
+For brand assets and guidelines, visit the [Brand Kit page](/brand-kit).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,9 +140,7 @@ const config = {
             label: 'Developer',
           },
           {
-            type: 'docSidebar',
-            sidebarId: 'defaultSidebar',
-            docsPluginId: 'brand-kit',
+            to: '/brand-kit',
             position: 'right',
             label: 'Brand Kit',
           },

--- a/src/pages/brand-kit.js
+++ b/src/pages/brand-kit.js
@@ -1,0 +1,505 @@
+import React, { useState, useCallback } from 'react';
+import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
+import styles from './brand-kit.module.css';
+
+// Copy to clipboard utility with feedback
+function useCopyToClipboard() {
+  const [copiedItem, setCopiedItem] = useState(null);
+
+  const copy = useCallback(async (text, itemId) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedItem(itemId);
+      setTimeout(() => setCopiedItem(null), 2000);
+      return true;
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      return false;
+    }
+  }, []);
+
+  return { copy, copiedItem };
+}
+
+// Hero Section
+function HeroSection() {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroContent}>
+        <h1 className={styles.heroTitle}>Brand Kit</h1>
+        <p className={styles.heroSubtitle}>
+          Everything you need to represent Peer correctly. Download logos, access color codes, and follow our brand guidelines.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+// Logo Card Component
+function LogoCard({ name, description, imageSrc, svgPath, pngPath, isDark, copy, copiedItem }) {
+  const [svgContent, setSvgContent] = useState(null);
+  const itemId = `svg-${name}`;
+
+  const handleCopySvg = async () => {
+    if (!svgContent) {
+      try {
+        const response = await fetch(svgPath);
+        const text = await response.text();
+        setSvgContent(text);
+        copy(text, itemId);
+      } catch (err) {
+        console.error('Failed to fetch SVG:', err);
+      }
+    } else {
+      copy(svgContent, itemId);
+    }
+  };
+
+  return (
+    <div className={`${styles.logoCard} ${isDark ? styles.logoCardDark : styles.logoCardLight}`}>
+      <div className={styles.logoPreview}>
+        <img src={imageSrc} alt={`${name} logo`} loading="lazy" />
+      </div>
+      <div className={styles.logoInfo}>
+        <h3 className={styles.logoName}>{name}</h3>
+        <p className={styles.logoDescription}>{description}</p>
+      </div>
+      <div className={styles.logoActions}>
+        {svgPath && (
+          <button
+            className={styles.copyButton}
+            onClick={handleCopySvg}
+            aria-label={`Copy ${name} SVG code`}
+          >
+            {copiedItem === itemId ? 'Copied!' : 'Copy SVG'}
+          </button>
+        )}
+        <div className={styles.downloadLinks}>
+          {svgPath && (
+            <a href={svgPath} download className={styles.downloadLink}>
+              SVG
+            </a>
+          )}
+          {pngPath && (
+            <a href={pngPath} download className={styles.downloadLink}>
+              PNG
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Logo Guidelines Component
+function LogoGuidelines() {
+  const logoDos = [
+    'Use gradient version wherever possible',
+    'Give logo space to breathe',
+    'Position in corners for balance',
+  ];
+
+  const logoDonts = [
+    "Don't change the logo lockup",
+    "Don't blur the logo",
+    "Don't rotate (except 90°)",
+    "Don't change the logotype",
+    "Don't apply effects",
+    "Don't squash/stretch",
+    "Don't encroach on clear space",
+    "Don't use unapproved colours",
+  ];
+
+  return (
+    <div className={styles.guidelinesInline}>
+      <h3 className={styles.subsectionTitle}>Usage Guidelines</h3>
+      <div className={styles.guidelinesGridInline}>
+        <div className={styles.guidelineBlock}>
+          <h4 className={styles.guidelineTitle}>Do's</h4>
+          <ul className={styles.guidelineList}>
+            {logoDos.map((item, idx) => (
+              <li key={idx} className={styles.guidelineItemDo}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="20,6 9,17 4,12" />
+                </svg>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className={styles.guidelineBlock}>
+          <h4 className={styles.guidelineTitle}>Don'ts</h4>
+          <ul className={styles.guidelineList}>
+            {logoDonts.map((item, idx) => (
+              <li key={idx} className={styles.guidelineItemDont}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className={styles.sizeSpecsContainerInline}>
+        <h4 className={styles.guidelineTitle}>Minimum Size &amp; Clear Space</h4>
+        <div className={styles.sizeSpecsGrid}>
+          <div className={styles.sizeSpec}>
+            <span className={styles.sizeSpecLabel}>Screen</span>
+            <span className={styles.sizeSpecValue}>22px minimum height</span>
+          </div>
+          <div className={styles.sizeSpec}>
+            <span className={styles.sizeSpecLabel}>Print</span>
+            <span className={styles.sizeSpecValue}>0.24 inches minimum</span>
+          </div>
+          <div className={styles.sizeSpec}>
+            <span className={styles.sizeSpecLabel}>Clear Space</span>
+            <span className={styles.sizeSpecValue}>Equal to logo height on all sides</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Logo Section (01)
+function LogoSection({ copy, copiedItem }) {
+  const logos = [
+    {
+      name: 'Gradient / Colour',
+      description: 'Primary logo for dark backgrounds. Use wherever possible.',
+      imageSrc: '/img/brand-kit/logos/peer-logo-colour.svg',
+      svgPath: '/img/brand-kit/logos/peer-logo-colour.svg',
+      pngPath: '/img/brand-kit/logos/peer-logo-colour.png',
+      isDark: true,
+    },
+    {
+      name: 'White',
+      description: 'For dark backgrounds when gradient is not suitable.',
+      imageSrc: '/img/brand-kit/logos/peer-logo-white.svg',
+      svgPath: '/img/brand-kit/logos/peer-logo-white.svg',
+      pngPath: '/img/brand-kit/logos/peer-logo-white.png',
+      isDark: true,
+    },
+    {
+      name: 'Black',
+      description: 'For light backgrounds only.',
+      imageSrc: '/img/brand-kit/logos/peer-logo-black.svg',
+      svgPath: '/img/brand-kit/logos/peer-logo-black.svg',
+      pngPath: '/img/brand-kit/logos/peer-logo-black.png',
+      isDark: false,
+    },
+    {
+      name: 'Profile Mark',
+      description: 'For social media avatars and app icons.',
+      imageSrc: '/img/brand-kit/logos/peer-profile.png',
+      svgPath: null,
+      pngPath: '/img/brand-kit/logos/peer-profile.png',
+      isDark: true,
+    },
+  ];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionNumber}>01</span>
+        <h2 className={styles.sectionTitle}>Logos</h2>
+      </div>
+      <div className={styles.logoGrid}>
+        {logos.map((logo) => (
+          <LogoCard
+            key={logo.name}
+            {...logo}
+            copy={copy}
+            copiedItem={copiedItem}
+          />
+        ))}
+      </div>
+      <div className={styles.downloadAllContainer}>
+        <a href="/brand-kit/peer-logos.zip" download className={styles.downloadAllButton}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7,10 12,15 17,10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          Download All Logos (ZIP)
+        </a>
+      </div>
+      <LogoGuidelines />
+    </section>
+  );
+}
+
+// Generate SVG content for color swatch
+function generateColorSvg(name, hex, isGradient, gradientFrom, gradientTo) {
+  if (isGradient) {
+    return `<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ignition" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="${gradientFrom}"/>
+      <stop offset="100%" stop-color="${gradientTo}"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#ignition)"/>
+</svg>`;
+  }
+  return `<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="400" height="400" fill="${hex}"/>
+</svg>`;
+}
+
+// Color Swatch Component
+function ColorSwatch({ name, hex, isGradient, gradientFrom, gradientTo, copy, copiedItem }) {
+  const itemId = `color-${name}`;
+  const displayValue = isGradient ? `${gradientFrom} → ${gradientTo}` : hex;
+  const copyValue = isGradient ? `linear-gradient(90deg, ${gradientFrom} 0%, ${gradientTo} 100%)` : hex;
+
+  const swatchStyle = isGradient
+    ? { background: `linear-gradient(90deg, ${gradientFrom} 0%, ${gradientTo} 100%)` }
+    : { background: hex };
+
+  const needsBorder = hex === '#FFFFFF' || hex === '#EEEEEE';
+
+  const handleDownload = (e) => {
+    e.stopPropagation();
+    const svgContent = generateColorSvg(name, hex, isGradient, gradientFrom, gradientTo);
+    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `peer-color-${name.toLowerCase().replace(/\s+/g, '-')}.svg`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className={styles.colorSwatchCard}>
+      <button
+        className={styles.colorSwatchClickable}
+        onClick={() => copy(copyValue, itemId)}
+        aria-label={`Copy ${name} color code`}
+      >
+        <div
+          className={`${styles.colorSwatch} ${needsBorder ? styles.colorSwatchBordered : ''}`}
+          style={swatchStyle}
+        />
+        <div className={styles.colorInfo}>
+          <span className={styles.colorName}>{name}</span>
+          <span className={styles.colorHex}>
+            {copiedItem === itemId ? 'Copied!' : displayValue}
+          </span>
+        </div>
+      </button>
+      <button
+        className={styles.colorDownloadButton}
+        onClick={handleDownload}
+        aria-label={`Download ${name} color swatch`}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="7,10 12,15 17,10" />
+          <line x1="12" y1="15" x2="12" y2="3" />
+        </svg>
+        SVG
+      </button>
+    </div>
+  );
+}
+
+// Color Section (02)
+function ColorSection({ copy, copiedItem }) {
+  const colors = [
+    { name: 'Black', hex: '#000000' },
+    { name: 'White', hex: '#FFFFFF' },
+    { name: 'Ignition', isGradient: true, gradientFrom: '#FF3A33', gradientTo: '#FFE500' },
+    { name: 'Light Grey', hex: '#EEEEEE' },
+  ];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionNumber}>02</span>
+        <h2 className={styles.sectionTitle}>Colors</h2>
+      </div>
+      <div className={styles.colorGrid}>
+        {colors.map((color) => (
+          <ColorSwatch
+            key={color.name}
+            {...color}
+            copy={copy}
+            copiedItem={copiedItem}
+          />
+        ))}
+      </div>
+      <p className={styles.colorNote}>
+        <strong>Ignition</strong> is the signature Peer gradient. Use for primary brand expression, CTAs, and key visual elements.
+      </p>
+    </section>
+  );
+}
+
+// Typography Guidelines Component
+function TypographyGuidelines() {
+  const typographyDonts = [
+    "Don't use unapproved typefaces",
+    "Don't apply effects to typefaces",
+    "Don't tilt (except 0° or 90°)",
+    "Don't mix lower and upper case",
+    "Don't use unapproved colors",
+    "Don't stray from recommended spacing",
+    "Don't use PP Valve for small copy",
+    "Don't use stroke or outlines",
+  ];
+
+  return (
+    <div className={styles.guidelinesInline}>
+      <h3 className={styles.subsectionTitle}>Usage Guidelines</h3>
+      <div className={styles.guidelineBlockWide}>
+        <h4 className={styles.guidelineTitle}>Don'ts</h4>
+        <ul className={styles.guidelineListGrid}>
+          {typographyDonts.map((item, idx) => (
+            <li key={idx} className={styles.guidelineItemDont}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+// Typography Section (03)
+function TypographySection() {
+  const typographyRules = [
+    { number: '1', title: 'Stay left-aligned, rag right', description: 'Text should be left-aligned with a natural rag on the right side.' },
+    { number: '2', title: 'All caps and double size', description: 'Headlines use PP Valve in uppercase at prominent sizes.' },
+    { number: '3', title: 'Align x-heights or baselines', description: 'When mixing type sizes, align on x-heights or baselines for visual harmony.' },
+    { number: '4', title: 'Watch the rag', description: 'Avoid awkward line breaks and maintain a balanced text shape.' },
+    { number: '5', title: 'Give things space', description: 'Use generous whitespace around type elements.' },
+    { number: '6', title: 'Keep line length reasonable', description: 'Optimal line length is 45-70 characters for readability.' },
+  ];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionNumber}>03</span>
+        <h2 className={styles.sectionTitle}>Typography</h2>
+      </div>
+
+      <div className={styles.typefaceGrid}>
+        <div className={styles.typefaceCard}>
+          <span className={styles.typefaceLabel}>Headlines</span>
+          <h3 className={styles.typefaceName}>PP Valve</h3>
+          <p className={styles.typefaceSpecimen}>ABCDEFGHIJKLMNOPQRSTUVWXYZ</p>
+          <p className={styles.typefaceNote}>Always uppercase, Semibold weight</p>
+        </div>
+
+        <div className={styles.typefaceCard}>
+          <span className={styles.typefaceLabel}>Body</span>
+          <h3 className={styles.typefaceNameBody}>Inter</h3>
+          <p className={styles.typefaceSpecimenBody}>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</p>
+          <p className={styles.typefaceNote}>Regular weight for body text</p>
+        </div>
+      </div>
+
+      <h3 className={styles.subsectionTitle}>Typography Rules</h3>
+      <div className={styles.rulesGrid}>
+        {typographyRules.map((rule) => (
+          <div key={rule.number} className={styles.ruleCard}>
+            <span className={styles.ruleNumber}>{rule.number}</span>
+            <h4 className={styles.ruleTitle}>{rule.title}</h4>
+            <p className={styles.ruleDescription}>{rule.description}</p>
+          </div>
+        ))}
+      </div>
+
+      <TypographyGuidelines />
+    </section>
+  );
+}
+
+// Download Section (04)
+function DownloadSection() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionNumber}>04</span>
+        <h2 className={styles.sectionTitle}>Downloads</h2>
+      </div>
+      <div className={styles.downloadGrid}>
+        <a href="/brand-kit/peer-logos.zip" download className={styles.downloadCard}>
+          <div className={styles.downloadIcon}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7,10 12,15 17,10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </div>
+          <div className={styles.downloadInfo}>
+            <span className={styles.downloadTitle}>Logo Package</span>
+            <span className={styles.downloadDescription}>All logo variants in SVG and PNG formats</span>
+          </div>
+        </a>
+
+        <a
+          href="https://drive.google.com/drive/folders/1ejYBILtBY10tNVrIySfcUC-mI07iFRUW"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.downloadCard}
+        >
+          <div className={styles.downloadIcon}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            </svg>
+          </div>
+          <div className={styles.downloadInfo}>
+            <span className={styles.downloadTitle}>Full Brand Kit</span>
+            <span className={styles.downloadDescription}>Complete brand guidelines, assets, and templates</span>
+          </div>
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// Main Brand Kit Page
+export default function BrandKit() {
+  const { copy, copiedItem } = useCopyToClipboard();
+
+  return (
+    <Layout
+      title="Brand Kit"
+      description="Peer brand assets, guidelines, and resources for partners and designers.">
+      <Head>
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://docs.peer.xyz/brand-kit" />
+        <meta property="og:title" content="Peer Brand Kit" />
+        <meta property="og:description" content="Download Peer logos, colors, and brand guidelines." />
+        <meta property="og:image" content="https://docs.peer.xyz/img/banner.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Peer Brand Kit" />
+        <meta name="twitter:description" content="Download Peer logos, colors, and brand guidelines." />
+        <meta name="twitter:image" content="https://docs.peer.xyz/img/banner.png" />
+      </Head>
+      <main className={styles.brandKit}>
+        <HeroSection />
+        <div className={styles.container}>
+          <LogoSection copy={copy} copiedItem={copiedItem} />
+          <ColorSection copy={copy} copiedItem={copiedItem} />
+          <TypographySection />
+          <DownloadSection />
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/brand-kit.module.css
+++ b/src/pages/brand-kit.module.css
@@ -1,0 +1,733 @@
+/* Brand Kit Page Styles */
+
+/* Main container */
+.brandKit {
+  min-height: 100vh;
+  background: var(--peer-black);
+  color: var(--peer-white);
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+}
+
+/* Hero Section */
+.hero {
+  padding: 4rem 2rem 3rem;
+  text-align: center;
+  position: relative;
+}
+
+.heroContent {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.heroTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  line-height: var(--peer-line-height-headline);
+  margin-bottom: 1rem;
+  color: var(--peer-white);
+}
+
+.heroSubtitle {
+  font-size: clamp(1rem, 1.5vw, 1.25rem);
+  color: var(--peer-light-grey);
+  line-height: 1.6;
+  font-weight: var(--peer-font-weight-medium);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Section Styles */
+.section {
+  padding: 3rem 0;
+  border-top: 1px solid var(--peer-border-dark);
+}
+
+.section:first-of-type {
+  border-top: none;
+}
+
+.sectionHeader {
+  margin-bottom: 2rem;
+}
+
+.sectionNumber {
+  display: block;
+  font-family: var(--peer-font-body);
+  font-size: 14px;
+  font-weight: var(--peer-font-weight-semibold);
+  color: var(--peer-grey);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+.sectionTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  line-height: var(--peer-line-height-headline);
+  color: var(--peer-white);
+  margin: 0;
+}
+
+.subsectionTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+  margin: 2.5rem 0 1.5rem;
+}
+
+/* Logo Section */
+.logoGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.logoCard {
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--peer-border-dark);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.logoCard:hover {
+  border-color: var(--peer-docs-border-hover);
+  transform: translateY(-2px);
+}
+
+.logoCardDark {
+  background: var(--peer-rich-black);
+}
+
+.logoCardLight {
+  background: var(--peer-light-grey);
+}
+
+.logoPreview {
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border-radius: var(--peer-radius-md);
+  overflow: hidden;
+}
+
+.logoCardDark .logoPreview {
+  background: var(--peer-obsidian);
+}
+
+.logoCardLight .logoPreview {
+  background: var(--peer-white);
+}
+
+.logoPreview img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.logoInfo {
+  flex: 1;
+}
+
+.logoName {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  margin: 0 0 0.25rem;
+}
+
+.logoCardDark .logoName {
+  color: var(--peer-white);
+}
+
+.logoCardLight .logoName {
+  color: var(--peer-black);
+}
+
+.logoDescription {
+  font-size: var(--peer-font-size-body-sm);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.logoCardDark .logoDescription {
+  color: var(--peer-light-grey);
+}
+
+.logoCardLight .logoDescription {
+  color: var(--peer-grey);
+}
+
+.logoActions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.copyButton {
+  background: transparent;
+  border: 1px solid var(--peer-border-dark);
+  color: var(--peer-white);
+  padding: 0.5rem 1rem;
+  border-radius: var(--peer-radius-md);
+  font-family: var(--peer-font-body);
+  font-size: var(--peer-font-size-body-sm);
+  font-weight: var(--peer-font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.logoCardLight .copyButton {
+  border-color: var(--peer-border-card-light);
+  color: var(--peer-black);
+}
+
+.copyButton:hover {
+  border-color: var(--peer-ignite-yellow);
+  color: var(--peer-ignite-yellow);
+}
+
+.logoCardLight .copyButton:hover {
+  border-color: var(--peer-ignite-red);
+  color: var(--peer-ignite-red);
+}
+
+.downloadLinks {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.downloadLink {
+  font-size: var(--peer-font-size-body-sm);
+  font-weight: var(--peer-font-weight-semibold);
+  color: var(--peer-link);
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--peer-radius-sm);
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.downloadLink:hover {
+  color: var(--peer-white);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.logoCardLight .downloadLink {
+  color: var(--peer-link);
+}
+
+.logoCardLight .downloadLink:hover {
+  color: var(--peer-black);
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.downloadAllContainer {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.downloadAllButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: linear-gradient(90deg, #FF3A33 0%, #FFE500 100%);
+  color: var(--peer-black);
+  padding: 1rem 2rem;
+  border-radius: var(--peer-radius-lg);
+  font-family: var(--peer-font-body);
+  font-size: var(--peer-font-size-button);
+  font-weight: var(--peer-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-button);
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 24px rgba(255, 58, 51, 0.25);
+}
+
+.downloadAllButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(255, 58, 51, 0.35);
+  background: linear-gradient(270deg, #FF3A33 0%, #FFE500 100%);
+}
+
+/* Color Section */
+.colorGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.colorSwatchCard {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.25rem;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+  text-align: left;
+  width: 100%;
+}
+
+.colorSwatchCard:hover {
+  border-color: var(--peer-docs-border-hover);
+  transform: translateY(-2px);
+}
+
+.colorSwatchClickable {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.colorDownloadButton {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-sm);
+  color: var(--peer-light-grey);
+  font-size: var(--peer-font-size-body-sm);
+  font-weight: var(--peer-font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.colorDownloadButton:hover {
+  border-color: var(--peer-ignite-yellow);
+  color: var(--peer-ignite-yellow);
+}
+
+.colorSwatch {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: var(--peer-radius-md);
+  margin-bottom: 1rem;
+}
+
+.colorSwatchBordered {
+  border: 1px solid var(--peer-border-dark);
+}
+
+.colorInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.colorName {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+}
+
+.colorHex {
+  font-family: var(--peer-font-body);
+  font-size: var(--peer-font-size-body-sm);
+  color: var(--peer-light-grey);
+  font-weight: var(--peer-font-weight-medium);
+}
+
+.colorNote {
+  margin-top: 1.5rem;
+  font-size: var(--peer-font-size-body-sm);
+  color: var(--peer-light-grey);
+  line-height: 1.6;
+}
+
+.colorNote strong {
+  color: var(--peer-white);
+}
+
+/* Typography Section */
+.typefaceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.typefaceCard {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+}
+
+.typefaceLabel {
+  display: block;
+  font-size: var(--peer-font-size-caption);
+  font-weight: var(--peer-font-weight-semibold);
+  color: var(--peer-grey);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+.typefaceName {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 2rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+  margin: 0 0 1rem;
+}
+
+.typefaceNameBody {
+  font-family: var(--peer-font-body);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 2rem;
+  color: var(--peer-white);
+  margin: 0 0 1rem;
+}
+
+.typefaceSpecimen {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--peer-light-grey);
+  word-break: break-all;
+  line-height: 1.4;
+  margin: 0 0 1rem;
+}
+
+.typefaceSpecimenBody {
+  font-family: var(--peer-font-body);
+  font-weight: var(--peer-font-weight-medium);
+  font-size: 1rem;
+  color: var(--peer-light-grey);
+  word-break: break-all;
+  line-height: 1.4;
+  margin: 0 0 1rem;
+}
+
+.typefaceNote {
+  font-size: var(--peer-font-size-body-sm);
+  color: var(--peer-grey);
+  margin: 0;
+}
+
+/* Typography Rules */
+.rulesGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.ruleCard {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-lg);
+  padding: 1.25rem;
+  transition: border-color 0.2s ease;
+}
+
+.ruleCard:hover {
+  border-color: var(--peer-docs-border-hover);
+}
+
+.ruleNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: linear-gradient(90deg, #FF3A33 0%, #FFE500 100%);
+  color: var(--peer-black);
+  font-family: var(--peer-font-body);
+  font-weight: var(--peer-font-weight-bold);
+  font-size: var(--peer-font-size-body-sm);
+  border-radius: var(--peer-radius-full);
+  margin-bottom: 0.75rem;
+}
+
+.ruleTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+  margin: 0 0 0.5rem;
+}
+
+.ruleDescription {
+  font-size: var(--peer-font-size-body-sm);
+  color: var(--peer-light-grey);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Guidelines Section */
+.guidelinesGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.guidelineBlock {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+}
+
+.guidelineTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+  margin: 0 0 1rem;
+}
+
+.guidelineList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.guidelineItemDo,
+.guidelineItemDont {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: var(--peer-font-size-body-sm);
+  line-height: 1.4;
+  color: var(--peer-light-grey);
+}
+
+.guidelineItemDo svg {
+  color: var(--peer-success);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.guidelineItemDont svg {
+  color: var(--peer-error);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+/* Size Specs */
+.sizeSpecsContainer {
+  margin-top: 2rem;
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+}
+
+.sizeSpecsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.sizeSpec {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sizeSpecLabel {
+  font-size: var(--peer-font-size-caption);
+  font-weight: var(--peer-font-weight-semibold);
+  color: var(--peer-grey);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.sizeSpecValue {
+  font-size: var(--peer-font-size-body);
+  color: var(--peer-white);
+  font-weight: var(--peer-font-weight-medium);
+}
+
+/* Download Section */
+.downloadGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.downloadCard {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  text-decoration: none;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.downloadCard:hover {
+  border-color: var(--peer-docs-border-hover);
+  transform: translateY(-2px);
+  background: rgba(32, 32, 32, 0.95);
+}
+
+.downloadIcon {
+  width: 48px;
+  height: 48px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--peer-radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--peer-white);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.downloadCard:hover .downloadIcon {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.downloadInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.downloadTitle {
+  font-family: var(--peer-font-headline);
+  font-weight: var(--peer-font-weight-semibold);
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  letter-spacing: var(--peer-letter-spacing-snug);
+  color: var(--peer-white);
+}
+
+.downloadDescription {
+  font-size: var(--peer-font-size-body-sm);
+  color: var(--peer-light-grey);
+  line-height: 1.4;
+}
+
+/* Inline Guidelines (within sections) */
+.guidelinesInline {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--peer-border-dark);
+}
+
+.guidelinesGridInline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.guidelineBlockWide {
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+}
+
+.guidelineListGrid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.sizeSpecsContainerInline {
+  margin-top: 1.5rem;
+  background: var(--peer-rich-black);
+  border: 1px solid var(--peer-border-dark);
+  border-radius: var(--peer-radius-xl);
+  padding: 1.5rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .container {
+    padding: 0 1.5rem 3rem;
+  }
+
+  .hero {
+    padding: 3rem 1.5rem 2rem;
+  }
+
+  .section {
+    padding: 2rem 0;
+  }
+
+  .logoGrid,
+  .colorGrid,
+  .typefaceGrid,
+  .rulesGrid,
+  .guidelinesGrid,
+  .downloadGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .logoActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .downloadLinks {
+    justify-content: center;
+  }
+
+  .sizeSpecsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logoCard,
+  .colorSwatchCard,
+  .ruleCard,
+  .downloadCard,
+  .downloadAllButton,
+  .copyButton,
+  .downloadLink {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Creates new React-based brand kit page at `/brand-kit` with interactive features
- Adds logo section with copy SVG to clipboard and download (SVG/PNG) functionality
- Adds color swatches with click-to-copy hex codes and downloadable SVG swatches
- Adds typography specimens (PP Valve, Inter) and 6 typography rules
- Integrates usage guidelines (do's/don'ts) inline under each relevant section
- Updates navbar link to point directly to new page

## Features
- **Copy to clipboard**: SVG code for logos, hex values for colors
- **Download buttons**: Individual logo downloads (SVG/PNG), color swatch SVGs, full logo ZIP
- **Full Brand Kit**: Links to Google Drive for complete brand guidelines
- **Responsive design**: Grid layouts adapt to mobile
- **Peer brand styling**: Ignition gradient, glassmorphic cards, dark theme

## Test plan
- [ ] Page loads at `/brand-kit`
- [ ] All logo images display correctly
- [ ] Copy SVG buttons work (check clipboard)
- [ ] Copy hex code buttons work
- [ ] Download links work (logos + color swatches)
- [ ] Responsive on mobile (< 768px)
- [ ] Typography specimens render with correct fonts
- [ ] Guidelines display correctly under each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)