### PR TITLE
fix: mobile sidebar not rendering due to backdrop-filter containing block

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -474,6 +474,20 @@ svg[data-icon="external-link"] {
 /* ===========================
    Sidebar
    =========================== */
+
+/* Fix: backdrop-filter on .navbar creates a containing block, causing
+   .navbar-sidebar (position:fixed) to resolve height:100% against the
+   navbar (~60px) instead of the viewport. Use viewport units instead. */
+.navbar-sidebar {
+  height: 100vh;
+  height: 100dvh;
+}
+
+.navbar-sidebar__items {
+  height: calc(100vh - var(--ifm-navbar-height));
+  height: calc(100dvh - var(--ifm-navbar-height));
+}
+
 .theme-doc-sidebar-container {
   background: var(--zkp2p-background);
   border-right: 1px solid rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## Summary
- The `backdrop-filter` on `.navbar` creates a new CSS containing block, which causes `.navbar-sidebar` (`position: fixed`) to resolve `height: 100%` against the navbar height (~60px) instead of the viewport
- The sidebar items container ended up with `height: 0px`, making the mobile nav invisible
- Switched to `100dvh` viewport units so the sidebar fills the screen regardless of containing block

## Test plan
- [x] Verified mobile sidebar opens and shows navigation links at 390x844 viewport
- [x] Verified desktop layout unchanged (sidebar, content, TOC all render correctly)
- [x] Build succeeds with no errors

Closes ZKP2P-1711