### PR TITLE
React doctor one shot fixes

### DIFF
--- a/src/brand/src/components/GradientText.tsx
+++ b/src/brand/src/components/GradientText.tsx
@@ -98,6 +98,8 @@ const ensureGradientShiftKeyframes = () => {
   hasInjectedGradientShift = true;
 };
 
+ensureGradientShiftKeyframes();
+
 const usePrefersReducedMotion = () => {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
@@ -159,12 +161,6 @@ export function GradientText({
   const gradient = gradientMap[variant];
   const prefersReducedMotion = usePrefersReducedMotion();
   const shouldAnimate = animate && !prefersReducedMotion;
-
-  useEffect(() => {
-    if (shouldAnimate) {
-      ensureGradientShiftKeyframes();
-    }
-  }, [shouldAnimate]);
 
   const combinedStyles: CSSProperties = {
     ...baseStyles,

--- a/src/brand/src/components/Icon.tsx
+++ b/src/brand/src/components/Icon.tsx
@@ -1,6 +1,5 @@
 import {
-  useEffect,
-  useState,
+  useSyncExternalStore,
   type CSSProperties,
   type HTMLAttributes,
 } from "react";
@@ -70,6 +69,9 @@ const supportsMasking = () => {
   );
 };
 
+const subscribeMasking = () => () => {};
+const serverSnapshot = () => true;
+
 /**
  * Peer Icon Component
  *
@@ -112,11 +114,7 @@ export function Icon({
     restProps.role ?? (hasAccessibleName ? "img" : "presentation");
   const resolvedAriaHidden =
     restProps["aria-hidden"] ?? (hasAccessibleName ? undefined : true);
-  const [useMask, setUseMask] = useState(true);
-
-  useEffect(() => {
-    setUseMask(supportsMasking());
-  }, []);
+  const useMask = useSyncExternalStore(subscribeMasking, supportsMasking, serverSnapshot);
 
   if (!useMask) {
     return (


### PR DESCRIPTION
## Summary
- **Icon component**: Replaced `useState` + `useEffect` pattern with `useSyncExternalStore` for CSS mask support detection, eliminating a hydration flash on mount
- **GradientText component**: Moved gradient keyframe style injection to module level (eager, idempotent), removing the `useEffect` that was simulating an event handler

## Context

Ran `npx react-doctor@latest` which reported a score of **98/100** with 16 warnings:
- 1x `rendering-hydration-no-flicker` in `Icon.tsx`
- 1x `no-effect-event-handler` in `GradientText.tsx`
- 14x unused file warnings (false positives — all in `src/brand/` which is a standalone design system package)

The 14 unused file warnings are false positives from knip — those files are exports of the `@zkp2p/brand` package consumed by other repos.

## Test plan
- [x] `yarn build` passes successfully