### PR TITLE
Document ARM, DRM, and SDK behavior across docs

### DIFF
--- a/developer-sidebars.js
+++ b/developer-sidebars.js
@@ -6,6 +6,16 @@ module.exports = {
       label: 'Onramp Integration',
     },
     { type: 'doc', id: 'offramp-integration', label: 'Offramp Integration' },
+    {
+      type: 'doc',
+      id: 'automated-rate-management',
+      label: 'Automated Rate Management',
+    },
+    {
+      type: 'doc',
+      id: 'delegated-rate-management',
+      label: 'Delegated Rate Management',
+    },
     { type: 'doc', id: 'post-intent-hooks', label: 'Post‑Intent Hooks' },
     { type: 'doc', id: 'build-payment-integration', label: 'Build a Payment Integration' },
   ],

--- a/developer/automated-rate-management.md
+++ b/developer/automated-rate-management.md
@@ -1,0 +1,116 @@
+---
+title: Automated Rate Management
+slug: /developer/automated-rate-management
+---
+
+# Automated Rate Management
+
+Automated rate management (ARM) is native EscrowV2 pricing logic.
+
+There is no separate ARM contract. A deposit tuple becomes "automated" when you combine:
+
+- a depositor-set fixed floor via `setCurrencyMinRate`, and/or
+- an oracle-backed spread config via `setOracleRateConfig`
+
+Peer's seller UI calls this mode `Market Tracking`.
+
+## Contract model
+
+ARM is configured per `(depositId, paymentMethod, currency)` tuple.
+
+Relevant EscrowV2 entry points:
+
+- `setCurrencyMinRate`
+- `setOracleRateConfig`
+- `setOracleRateConfigBatch`
+- `removeOracleRateConfig`
+- `getDepositCurrencyMinRate`
+- `getEffectiveRate`
+
+The tuple floor is resolved inside EscrowV2 as:
+
+```text
+escrowFloor = max(fixedFloor, oracleRateWithSpread)
+```
+
+If no rate manager is assigned, `getEffectiveRate` returns `escrowFloor`.
+
+## Oracle halt semantics
+
+This is the most important ARM edge case.
+
+If a tuple has an oracle configured and the adapter quote is invalid, stale, future-dated, or zero, EscrowV2 resolves that tuple to `0`.
+
+That means:
+
+- the tuple is halted
+- `getEffectiveRate` returns `0`
+- the fixed floor does not automatically take over while the oracle config is still present
+
+To restore fixed-floor-only behavior, remove the oracle config with `removeOracleRateConfig`.
+
+## SDK write examples
+
+```ts
+import {
+  resolveFiatCurrencyBytes32,
+  resolvePaymentMethodHash,
+} from '@zkp2p/sdk';
+
+const paymentMethodHash = resolvePaymentMethodHash('wise', { env: 'production' });
+const currencyHash = resolveFiatCurrencyBytes32('USD');
+
+await client.setCurrencyMinRate({
+  depositId: 42n,
+  paymentMethod: paymentMethodHash,
+  fiatCurrency: currencyHash,
+  minConversionRate: 1_020_000_000_000_000_000n,
+});
+
+await client.setOracleRateConfig({
+  depositId: 42n,
+  paymentMethodHash,
+  currencyHash,
+  config: {
+    adapter: '0xOracleAdapter',
+    adapterConfig: '0x',
+    spreadBps: 75,
+    maxStaleness: 180,
+  },
+});
+```
+
+Batch configuration is available through `setOracleRateConfigBatch` when you want to update several tuples in one transaction.
+
+## Read model
+
+Use the indexer `MethodCurrency` entity for the current resolved ARM state.
+
+Fields to rely on:
+
+- `minConversionRate`: depositor-set fixed floor
+- `adapter`, `adapterConfig`, `feed`, `feedDecimals`, `spreadBps`, `maxStaleness`, `invert`
+- `oracleRate`: raw oracle price before spread
+- `effectiveOracleRate`: oracle price after spread
+- `lastOracleUpdatedAt`
+- `conversionRate`: final resolved gross rate
+- `rateSource`
+
+`QuoteCandidate` is a denormalized quoting surface. It is useful for order book views, but it is not the authoritative ARM state model.
+
+## Interpreting `rateSource`
+
+`MethodCurrency.rateSource` tells you why the final rate resolved the way it did:
+
+- `ORACLE`: the oracle-backed spread floor beat the fixed floor
+- `ESCROW_FLOOR`: the fixed floor won, or there was no stronger oracle floor
+- `ORACLE_HALTED`: an oracle was configured, but the tuple resolved to zero
+- `NO_FLOOR`: neither a usable fixed floor nor a usable oracle floor existed
+
+If the deposit is delegated, you can also see `MANAGER` or `MANAGER_DISABLED`. Those are documented in [Delegated Rate Management](delegated-rate-management.md).
+
+## Operational guidance
+
+- Use `setCurrencyMinRate` even on oracle-backed tuples when you want an explicit minimum acceptable rate.
+- Treat `ORACLE_HALTED` as a blocking state. The tuple is not merely "degraded"; it is disabled until the oracle is usable again or removed.
+- Prefer `MethodCurrency` for UI state and alerting, because it already carries the resolved rate, source, and oracle metadata in one place.

--- a/developer/delegated-rate-management.md
+++ b/developer/delegated-rate-management.md
@@ -1,0 +1,180 @@
+---
+title: Delegated Rate Management
+slug: /developer/delegated-rate-management
+---
+
+# Delegated Rate Management
+
+Delegated rate management (DRM) lets a third-party manager control the active quote for a deposit without taking custody of the deposit funds.
+
+Peer's product surfaces call these managers `vaults`.
+
+:::note
+There is no separate onchain `Vault` entity on `main`. Protocol-side delegation is a `RateManager` contract plus a deposit-level assignment in EscrowV2.
+:::
+
+## Contract model
+
+Delegation has two layers:
+
+1. A manager contract implements `IRateManager`.
+2. A deposit opts into that manager through `EscrowV2.setRateManager`.
+
+Relevant EscrowV2 calls:
+
+- `setRateManager`
+- `clearRateManager`
+- `getDepositRateManager`
+- `getEffectiveRate`
+- `getManagerFee`
+
+Relevant manager calls in the reference `RateManagerV1` implementation:
+
+- `createRateManager`
+- `setRateManagerConfig`
+- `setFee`
+- `setMinLiquidity`
+- `setRate`
+- `setRateBatch`
+
+## Effective rate precedence
+
+DRM never bypasses the deposit floor.
+
+EscrowV2 resolves the active tuple rate in this order:
+
+1. Compute `escrowFloor` from fixed floor and/or oracle spread.
+2. If `escrowFloor == 0`, return `0`.
+3. If the deposit is not delegated, return `escrowFloor`.
+4. If delegated, ask the manager for a rate.
+5. If the manager returns `0`, the delegated tuple is disabled and the result is `0`.
+6. If the manager call reverts, EscrowV2 fails safe to `escrowFloor`.
+7. Otherwise, return `max(managerRate, escrowFloor)`.
+
+Implications:
+
+- a manager cannot undercut the depositor floor
+- a manager cannot revive a tuple that is halted by an invalid oracle
+- a manager can disable a tuple by returning `0`
+
+## SDK write examples
+
+Create a vault:
+
+```ts
+await client.createRateManager({
+  config: {
+    manager: '0xManager',
+    feeRecipient: '0xFeeRecipient',
+    maxFee: 50_000_000_000_000_000n,
+    fee: 10_000_000_000_000_000n,
+    minLiquidity: 1_000_000n,
+    name: 'USD Vault',
+    uri: 'ipfs://vault-metadata',
+  },
+});
+```
+
+Delegate a deposit directly through EscrowV2:
+
+```ts
+await client.setRateManager({
+  depositId: 42n,
+  rateManagerAddress: '0xRateManagerRegistry',
+  rateManagerId: '0xRateManagerId',
+});
+```
+
+Update manager-side rates and fees:
+
+```ts
+await client.setVaultMinRate({
+  rateManagerId: '0xRateManagerId',
+  paymentMethodHash: '0xPaymentMethodHash',
+  currencyHash: '0xCurrencyHash',
+  rate: 1_035_000_000_000_000_000n,
+});
+
+await client.setVaultFee({
+  rateManagerId: '0xRateManagerId',
+  newFee: 20_000_000_000_000_000n,
+});
+```
+
+Remove delegation:
+
+```ts
+await client.clearRateManager({ depositId: 42n });
+```
+
+If your app routes through the controller contract, the SDK also exposes `setDepositRateManager` and `clearDepositRateManager`.
+
+## Manager fees
+
+Manager fees are separate from the resolved gross rate.
+
+At the indexer layer:
+
+- `conversionRate` is the resolved gross rate before fee
+- `takerConversionRate` is the all-in rate after manager fee
+
+At the intent layer, the indexer snapshots:
+
+- `rateManagerId`
+- `managerFee`
+- `managerFeeRecipient`
+- `managerFeeAmount`
+- `realizedManagerFeeAmount`
+
+Use those fields for historical reporting. Do not recompute realized manager fees from today's vault settings.
+
+## Read model
+
+For vault discovery and analytics, use:
+
+```ts
+const managers = await client.indexer.getRateManagers({ limit: 25 });
+const detail = await client.indexer.getRateManagerDetail('0xRateManagerId');
+const delegations = await client.indexer.getRateManagerDelegations('0xRateManagerId');
+const delegation = await client.indexer.getDelegationForDeposit('42', {
+  escrowAddress: '0xEscrowAddress',
+});
+const history = await client.indexer.getManagerDailySnapshots('0xRateManagerId');
+const manualUpdates = await client.indexer.getManualRateUpdates('0xRateManagerId');
+const oracleUpdates = await client.indexer.getOracleConfigUpdates('0xRateManagerId');
+```
+
+For deposit-side rendering, rely on `Deposit` and `MethodCurrency`:
+
+- `Deposit.rateManagerId`
+- `Deposit.rateManagerAddress`
+- `Deposit.delegatedAt`
+- `MethodCurrency.managerRate`
+- `MethodCurrency.managerFee`
+- `MethodCurrency.rateManagerId`
+- `MethodCurrency.rateSource`
+
+## `rateSource` values during delegation
+
+- `MANAGER`: manager rate beat the escrow floor
+- `ESCROW_FLOOR`: the deposit floor won even though the tuple is delegated
+- `MANAGER_DISABLED`: the manager returned `0` for that tuple
+- `ORACLE_HALTED`: the deposit floor was halted before manager logic could apply
+
+## React hooks
+
+The React package exposes higher-level vault helpers:
+
+- `useCreateVault`
+- `useVaultDelegation`
+- `useSetVaultFee`
+- `useSetVaultMinRate`
+- `useSetVaultConfig`
+
+`useVaultDelegation` handles preflight simulation and supports batched clear-and-set flows when your wallet stack supports atomic batching.
+
+## Common mistakes
+
+- Do not treat `deposit.delegate` as vault delegation. It is a separate deposit admin role.
+- Do not assume vaults override depositor risk controls. The deposit floor still binds the final quote.
+- Do not use `QuoteCandidate` as your source of truth for delegated state. Use `Deposit`, `MethodCurrency`, `RateManager`, and intent snapshots instead.

--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -6,15 +6,16 @@ slug: /developer/offramp
 
 # Offramp Integration
 
-The ZKP2P Client SDK is a TypeScript SDK for liquidity providers who want to offer fiat off-ramp services on Base. Use it to create and manage USDC deposits, configure payment methods and currencies, and query on-chain state with RPC-first reads.
+Use `@zkp2p/sdk` to create and manage seller deposits, configure automated rate management, delegate pricing to vaults, and read deposit state from RPC or the indexer.
 
-## Who is this for?
+The current public client is `Zkp2pClient`.
 
-This SDK is designed for liquidity providers (peers) who want to:
-- Create and manage USDC deposits that accept fiat payments
-- Configure payment methods, currencies, and conversion rates
-- Monitor deposit utilization and manage liquidity
-- Earn fees by providing off-ramp services
+## What you can build
+
+- Seller dashboards that create and manage deposits
+- Backends that rebalance rates or toggle deposit state
+- Vault tooling for delegated rate management
+- Analytics surfaces that read deposit, intent, and manager state from `client.indexer.*`
 
 ## Installation
 
@@ -31,7 +32,7 @@ pnpm add @zkp2p/sdk viem
 ### Initialize the client
 
 ```ts
-import { OfframpClient } from '@zkp2p/sdk';
+import { Zkp2pClient } from '@zkp2p/sdk';
 import { createWalletClient, custom } from 'viem';
 import { base } from 'viem/chains';
 
@@ -40,50 +41,62 @@ const walletClient = createWalletClient({
   transport: custom(window.ethereum),
 });
 
-const client = new OfframpClient({
+const client = new Zkp2pClient({
   walletClient,
   chainId: base.id,
-  apiKey: 'YOUR_API_KEY', // Optional for API operations
+  runtimeEnv: 'production',
+  apiKey: 'YOUR_CURATOR_API_KEY',
+  indexerApiKey: 'YOUR_INDEXER_API_KEY',
 });
 ```
 
-## Core operations
+## Rate modes
 
-### Create a deposit
+Each deposit pair can run in one of three pricing modes:
+
+- `Fixed`: you set `minConversionRate` directly on the deposit.
+- `Automated Rate Management`: EscrowV2 applies an oracle-backed spread and enforces the higher of your fixed floor and the oracle-backed floor.
+- `Delegated`: a vault manager sets the active rate, but EscrowV2 still enforces the deposit floor.
+
+See [Automated Rate Management](automated-rate-management.md) and [Delegated Rate Management](delegated-rate-management.md) for the full behavior and edge cases.
+
+## Create a deposit
+
+`createDeposit` accepts product-friendly payment method names plus deposit metadata. It resolves the onchain payment method hashes for you.
 
 ```ts
 import { Currency } from '@zkp2p/sdk';
 
 await client.createDeposit({
   token: '0xUSDC_ADDRESS',
-  amount: 10000000000n, // 10,000 USDC (6 decimals)
+  amount: 10_000_000n,
   intentAmountRange: { min: 100000n, max: 1000000000n },
   processorNames: ['wise', 'revolut'],
   depositData: [
-    { email: 'maker@example.com' }, // Wise payment details
-    { tag: '@maker' },              // Revolut payment details
+    { email: 'maker@example.com' },
+    { tag: '@maker' },
   ],
   conversionRates: [
-    [{ currency: Currency.USD, conversionRate: '1020000000000000000' }], // 1.02 (18 decimals)
-    [{ currency: Currency.EUR, conversionRate: '950000000000000000' }],  // 0.95 (18 decimals)
+    [{ currency: Currency.USD, conversionRate: '1020000000000000000' }],
+    [{ currency: Currency.EUR, conversionRate: '950000000000000000' }],
   ],
-  onSuccess: ({ hash }) => console.log('Deposit created:', hash),
+  retainOnEmpty: true,
 });
 ```
 
-### Manage deposit settings
+`createDeposit` requires either:
+
+- `apiKey` or `authorizationToken`, so the SDK can register payee details through the curator API, or
+- `payeeDetailsHashes`, if your app already registered payee details separately.
+
+## Manage deposit settings
 
 ```ts
 await client.setAcceptingIntents({ depositId: 1n, accepting: true });
 
 await client.setIntentRange({ depositId: 1n, min: 50000n, max: 5000000n });
-
-await client.setCurrencyMinRate({
-  depositId: 1n,
-  paymentMethod: '0x...',
-  fiatCurrency: '0x...',
-  minConversionRate: 1020000n,
-});
+await client.setRetainOnEmpty({ depositId: 1n, retain: true });
+await client.setDelegate({ depositId: 1n, delegate: '0xDelegateAddress' });
 ```
 
 ### Fund management
@@ -94,7 +107,84 @@ await client.removeFunds({ depositId: 1n, amount: 1000000n });
 await client.withdrawDeposit({ depositId: 1n });
 ```
 
-## Querying on-chain data (RPC-first)
+## Direct rate updates
+
+For fixed-rate or floor updates, resolve the payment method and currency keys and call EscrowV2 helpers directly:
+
+```ts
+import {
+  resolveFiatCurrencyBytes32,
+  resolvePaymentMethodHash,
+} from '@zkp2p/sdk';
+
+const paymentMethod = resolvePaymentMethodHash('wise', { env: 'production' });
+const fiatCurrency = resolveFiatCurrencyBytes32('USD');
+
+await client.setCurrencyMinRate({
+  depositId: 42n,
+  paymentMethod,
+  fiatCurrency,
+  minConversionRate: 1_020_000_000_000_000_000n,
+});
+```
+
+For oracle-backed pricing, configure the tuple on EscrowV2:
+
+```ts
+await client.setOracleRateConfig({
+  depositId: 42n,
+  paymentMethodHash: paymentMethod,
+  currencyHash: fiatCurrency,
+  config: {
+    adapter: '0xOracleAdapter',
+    adapterConfig: '0x',
+    spreadBps: 75,
+    maxStaleness: 180,
+  },
+});
+```
+
+If you want to stop using the oracle for a pair, call `removeOracleRateConfig`. That restores pricing to the fixed floor only.
+
+## Vault / delegated pricing
+
+The SDK exposes both deposit-side delegation and manager-side vault administration.
+
+```ts
+await client.createRateManager({
+  config: {
+    manager: '0xManager',
+    feeRecipient: '0xFeeRecipient',
+    maxFee: 50_000_000_000_000_000n,
+    fee: 10_000_000_000_000_000n,
+    minLiquidity: 1_000_000n,
+    name: 'USD Vault',
+    uri: 'ipfs://vault-metadata',
+  },
+});
+
+await client.setRateManager({
+  depositId: 42n,
+  rateManagerAddress: '0xRateManagerRegistry',
+  rateManagerId: '0xRateManagerId',
+});
+
+await client.setVaultMinRate({
+  rateManagerId: '0xRateManagerId',
+  paymentMethodHash: paymentMethod,
+  currencyHash: fiatCurrency,
+  rate: 1_035_000_000_000_000_000n,
+});
+
+await client.setVaultFee({
+  rateManagerId: '0xRateManagerId',
+  newFee: 20_000_000_000_000_000n,
+});
+```
+
+If your environment routes delegation through a controller contract, the SDK also exposes `setDepositRateManager` and `clearDepositRateManager`.
+
+## Query on-chain state (RPC-first)
 
 ```ts
 const deposits = await client.getDeposits();
@@ -109,24 +199,56 @@ const intent = await client.getIntent('0xIntentHash...');
 
 ## Indexer queries
 
+Use RPC for immediate contract reads and `client.indexer` for richer ARM/DRM state.
+
 ```ts
 const deposits = await client.indexer.getDeposits(
-  { status: 'ACTIVE', minLiquidity: '1000000', depositor: '0xYourAddress' },
-  { limit: 50, orderBy: 'remainingDeposits', orderDirection: 'desc' }
+  { status: 'ACTIVE', depositor: '0xYourAddress' },
+  { limit: 50, orderBy: 'remainingDeposits', orderDirection: 'desc' },
 );
 
 const depositsWithRelations = await client.indexer.getDepositsWithRelations(
   { status: 'ACTIVE' },
   { limit: 50 },
-  { includeIntents: true, intentStatuses: ['SIGNALED'] }
+  { includeIntents: true, intentStatuses: ['SIGNALED'] },
 );
 
-const fulfillments = await client.indexer.getFulfilledIntentEvents(['0x...']);
+const vaults = await client.indexer.getRateManagers({ limit: 25 });
+const vaultDetail = await client.indexer.getRateManagerDetail('0xRateManagerId');
+const delegation = await client.indexer.getDelegationForDeposit('42', {
+  escrowAddress: '0xEscrowAddress',
+});
 ```
 
-## Payment methods
+For ARM and DRM, the most useful indexer entity is `MethodCurrency`. It includes:
 
-Supported payment platforms and keys:
+- `minConversionRate`: the depositor-set fixed floor
+- `managerRate`: the delegated manager quote before floor enforcement
+- `conversionRate`: the final resolved gross rate
+- `takerConversionRate`: the buyer-facing all-in rate after manager fee
+- `rateSource`: `MANAGER`, `ORACLE`, `ESCROW_FLOOR`, `MANAGER_DISABLED`, `ORACLE_HALTED`, or `NO_FLOOR`
+
+`Deposit` also carries `rateManagerId`, `rateManagerAddress`, and `delegatedAt`.
+
+## Payment methods and contract helpers
+
+The SDK exports helpers for payment method catalogs, bytes32 resolution, and deployments:
+
+```ts
+import {
+  getContracts,
+  getPaymentMethodsCatalog,
+  resolveFiatCurrencyBytes32,
+  resolvePaymentMethodHash,
+} from '@zkp2p/sdk';
+
+const { addresses } = getContracts(8453, 'production');
+const catalog = getPaymentMethodsCatalog(8453, 'production');
+const wiseHash = resolvePaymentMethodHash('wise', { env: 'production' });
+const usdHash = resolveFiatCurrencyBytes32('USD');
+```
+
+Supported payment platforms include:
 
 | Platform | Key |
 |----------|-----|
@@ -138,42 +260,6 @@ Supported payment platforms and keys:
 | Zelle | `zelle` |
 | Monzo | `monzo` |
 | MercadoPago | `mercadopago` |
-
-```ts
-import { getPaymentMethodsCatalog, PLATFORM_METADATA, PAYMENT_PLATFORMS } from '@zkp2p/sdk';
-
-console.log(PAYMENT_PLATFORMS);
-
-const methods = getPaymentMethodsCatalog(8453, 'production');
-const wiseHash = methods['wise'].paymentMethodHash;
-
-const wiseInfo = PLATFORM_METADATA['wise'];
-console.log(wiseInfo.displayName);
-```
-
-## Currency utilities
-
-```ts
-import {
-  Currency,
-  currencyInfo,
-  getCurrencyInfoFromHash,
-  resolveFiatCurrencyBytes32,
-} from '@zkp2p/sdk';
-
-const usd = Currency.USD;
-const info = currencyInfo[Currency.USD];
-const usdBytes = resolveFiatCurrencyBytes32('USD');
-```
-
-## Contract helpers
-
-```ts
-import { getContracts, getPaymentMethodsCatalog } from '@zkp2p/sdk';
-
-const { addresses, abis } = getContracts(8453, 'production');
-const catalog = getPaymentMethodsCatalog(8453, 'production');
-```
 
 ## Supported networks
 
@@ -203,6 +289,12 @@ if (result.hadAllowance) {
 }
 ```
 
+## Next pages
+
+- [Automated Rate Management](automated-rate-management.md)
+- [Delegated Rate Management](delegated-rate-management.md)
+- [Post-Intent Hooks](post-intent-hooks.md)
+
 ## Error handling
 
 ```ts
@@ -218,6 +310,12 @@ try {
   } else if (error instanceof ContractError) {
     console.error('Contract error:', error.message);
   }
+}
+```
+
+:::note
+`deposit.delegate` and delegated rate management solve different problems. A deposit delegate can update deposit config on behalf of the owner. A rate manager controls the active quote for delegated tuples.
+:::
 }
 ```
 

--- a/guides-sidebars.js
+++ b/guides-sidebars.js
@@ -23,6 +23,9 @@ module.exports = {
       link: { type: 'doc', id: 'for-sellers/index' },
       items: [
         'for-sellers/provide-liquidity-sell-usdc',
+        'for-sellers/market-tracking-arm',
+        'for-sellers/create-a-vault',
+        'for-sellers/delegate-to-a-vault',
         'for-sellers/provide-liquidity-diff-chain',
         'for-sellers/update-usdc-rates',
         'for-sellers/calculating-apr',

--- a/guides/for-sellers/create-a-vault.md
+++ b/guides/for-sellers/create-a-vault.md
@@ -1,0 +1,66 @@
+---
+id: create-a-vault
+title: How to Create a Vault
+---
+
+# How to Create a Vault
+
+A vault is Peer's user-facing version of delegated rate management.
+
+When you create a vault, you become the manager for delegated deposits. Deposit owners keep custody of their USDC and keep their own floor protection, while you set the active rates for the pairs their deposits delegate to your vault.
+
+## What vault managers control
+
+- Vault name and metadata
+- Vault fee
+- Minimum liquidity required to delegate
+- The active rate for each payment-method and currency pair
+
+## What vault managers do not control
+
+- The depositor's funds
+- The depositor's payment accounts
+- The depositor's floor protection
+- Whether a depositor stays delegated to the vault
+
+## Create a vault
+
+1. Open the **Vaults** section in Peer.
+2. Click **Create Vault**.
+3. Enter a vault name.
+4. Set the live fee and the max fee cap.
+5. Optionally set a minimum USDC balance required to delegate.
+6. Optionally add a metadata URI.
+7. Review the vault terms and submit the transaction.
+
+## Fee model
+
+- Vault fees are charged per order.
+- The fee cannot be raised above the vault's configured max fee.
+- Vault detail pages show both the current fee and the max fee.
+
+## Minimum liquidity
+
+Minimum liquidity is checked when a deposit opts into the vault.
+
+If a deposit's total liquidity is below the vault minimum, delegation is rejected until the depositor adds more funds.
+
+## Managing vault rates
+
+After the vault is created, you can set rates for any supported payment-method and currency pair. A delegated deposit only quotes if:
+
+- the vault has a non-zero rate for that pair
+- the depositor's own floor for that pair is still valid
+
+If the vault rate is lower than the depositor's floor, the depositor floor wins.
+
+## Operating tips
+
+- Keep your configured rates broad enough to cover the pairs depositors actually delegate.
+- Watch delegated balance, daily volume, and filled intents from the vault detail page.
+- Remember that setting a pair to zero effectively disables that pair for delegated deposits.
+
+## Related guides
+
+- [How to Delegate a Deposit to a Vault](delegate-to-a-vault.md)
+- [Automated Rate Management (Market Tracking)](market-tracking-arm.md)

--- a/guides/for-sellers/delegate-to-a-vault.md
+++ b/guides/for-sellers/delegate-to-a-vault.md
@@ -1,0 +1,68 @@
+---
+id: delegate-to-a-vault
+title: How to Delegate a Deposit to a Vault
+---
+
+# How to Delegate a Deposit to a Vault
+
+Delegating a deposit to a vault lets someone else manage the active rates for your deposit.
+
+This is useful when you want professional or shared rate management without giving up custody of your funds.
+
+## What changes when you delegate
+
+- The vault sets the active rate for delegated pairs.
+- Your deposit still keeps its own floor protection.
+- Vault fees can apply to orders routed through the vault.
+- You can remove delegation later.
+
+## What stays under your control
+
+- Your USDC remains in your deposit.
+- You still control adding funds, removing funds, pausing the deposit, and withdrawing.
+- You still control the payment methods and currencies on the deposit.
+- You still control the floor for each pair.
+
+## Before you delegate
+
+Check these vault details first:
+
+- current fee and max fee
+- supported rate coverage for the pairs you care about
+- total delegated balance and recent volume
+- any entry requirements, including minimum liquidity
+
+## Delegate a deposit
+
+1. Open the vault you want to use.
+2. Click **Delegate**.
+3. Select one or more eligible deposits.
+4. Review any restrictions or minimum-liquidity requirements.
+5. Submit the transaction.
+
+If a deposit is already delegated somewhere else, you may need to clear the old delegation first.
+
+## Reading delegated pricing
+
+Once delegated, Peer shows:
+
+- your **floor**
+- the **vault rate**
+- the resulting payout or buyer-facing rate
+- the **rate source**
+
+This lets you confirm whether the vault rate is active or whether your floor is the winning protection for that pair.
+
+## Remove delegation
+
+1. Open the deposit or the vault detail page.
+2. Choose **Remove Delegation** or **Undelegate**.
+3. Confirm the transaction.
+
+After removal, your deposit goes back to direct rate management, using either Fixed Rate or Market Tracking for each pair.
+
+## Related guides
+
+- [How to Create a Vault](create-a-vault.md)
+- [Automated Rate Management (Market Tracking)](market-tracking-arm.md)
+- [How to Update USDC Conversion Rates](update-usdc-rates.md)

--- a/guides/for-sellers/index.md
+++ b/guides/for-sellers/index.md
@@ -17,6 +17,9 @@ You don’t need to be online to manually release crypto. Simply **deposit USDC*
 Below are guides to get started as a seller of USDC on ZKP2P:
 
 - [How to Provide Liquidity and Sell USDC](provide-liquidity-sell-usdc.md)
+- [Automated Rate Management (Market Tracking)](market-tracking-arm.md)
+- [How to Create a Vault](create-a-vault.md)
+- [How to Delegate a Deposit to a Vault](delegate-to-a-vault.md)
 - [How to Provide Liquidity from another chain](provide-liquidity-diff-chain.md)
 - [How to Update USDC Conversion Rates](update-usdc-rates.md)
 - [Calculating APR](calculating-apr.md)

--- a/guides/for-sellers/market-tracking-arm.md
+++ b/guides/for-sellers/market-tracking-arm.md
@@ -1,0 +1,81 @@
+---
+id: market-tracking-arm
+title: Automated Rate Management (Market Tracking)
+---
+
+# Automated Rate Management (Market Tracking)
+
+Peer calls automated rate management **Market Tracking** in the seller UI.
+
+Use it when you want a deposit to follow live FX automatically instead of manually typing a fixed rate for every pair.
+
+## What you control
+
+- The **spread** you want above live FX.
+- An optional **floor** that protects you if the market moves against you.
+- Which payment methods and currencies should use market tracking.
+
+## How pricing works
+
+For each payment-method and currency pair:
+
+1. Peer reads the live oracle-backed market rate.
+2. Your configured spread is applied on top of that market rate.
+3. If you set a floor, the effective rate becomes the higher of:
+   - your floor
+   - the market-tracked rate
+
+That means you keep upside from the spread while still protecting a minimum rate.
+
+## When to use it
+
+Market Tracking works best when:
+
+- you want quotes to stay close to live FX
+- you offer several currencies and do not want to edit each one manually
+- you still want a minimum acceptable payout
+
+Fixed rates work better when:
+
+- you want a fully static price
+- the supported currency does not yet have market tracking support
+- you have a temporary special rate you do not want to follow the market
+
+## What happens if the oracle is stale?
+
+If the oracle price is stale, invalid, or unavailable for that pair, Peer halts quoting for that specific pair until fresh data is available.
+
+:::warning
+This does not withdraw your deposit or remove the payment method. It only disables quoting for the affected pair until the market input is usable again.
+:::
+
+## How to enable Market Tracking on a new deposit
+
+1. Open **Sell** and start a new deposit.
+2. Add your payment method and payee details.
+3. In the rate section, choose **Market Tracking**.
+4. Enter a spread percentage.
+5. Add an optional floor rate if you want downside protection.
+6. Review the effective rate preview and continue.
+
+## How to switch an existing pair to Market Tracking
+
+1. Open your deposit from the **Sell** tab.
+2. Go to the platform and currency you want to edit.
+3. Click the rate edit action.
+4. Switch the modal from **Fixed Rate** to **Market Tracking**.
+5. Enter the spread and optional floor.
+6. Sign the update transaction.
+
+## Best practices
+
+- Start with a modest spread and watch fill speed for a few days.
+- Use a floor on thin or volatile currency pairs.
+- Review the liquidity table regularly so you do not drift too far above competing deposits.
+- If a pair stops quoting, check whether that currency supports market tracking and whether the oracle feed is fresh.
+
+## Related guides
+
+- [How to Provide Liquidity and Sell USDC](provide-liquidity-sell-usdc.md)
+- [How to Update USDC Conversion Rates](update-usdc-rates.md)
+- [How to Delegate a Deposit to a Vault](delegate-to-a-vault.md)

--- a/guides/for-sellers/provide-liquidity-sell-usdc.md
+++ b/guides/for-sellers/provide-liquidity-sell-usdc.md
@@ -5,7 +5,7 @@ title: How to Provide Liquidity and Sell USDC
 
 # How to Provide Liquidity and Sell USDC
 
-This guide will walk you through the process of providing liquidity on ZKP2P.
+This guide walks through creating a seller deposit on Peer. It also shows where rate management fits in: you can run your deposit with a fixed rate, turn on market tracking, or later delegate pricing to a vault.
 
 ### Step 1: Navigate to ZKP2P
 
@@ -100,19 +100,26 @@ Enter your username/account details for the selected platform:
 ![Provide Step 10](/img/provide-liquidity/ProvideStep9.png)
 
 
-### Step 11: Set Exchange Rates
+### Step 11: Choose a Rate Mode and Set Rates
 
-- Enter how much you want to sell your USDC for in each currency  
-- Adjust based on what you observed in Step 2
-- You can see your percentage spread in the middle column
-    - Green is above market rate, Grey is close to market rate, and Red is below market rate. 
+- Choose **Fixed Rate** if you want to enter an exact price for each currency yourself.
+- Choose **Market Tracking** if you want Peer to follow live FX and apply your spread automatically.
+- If you use market tracking, you can also set an optional **floor** to protect your minimum payout.
+- You can see your spread in the middle column:
+  - Green is above market rate
+  - Grey is close to market rate
+  - Red is below market rate
 
 💡 **Consider**:
 - Market demand  
 - Competitive rates  
 - Desired profit margin
 
-View the guide on optimal currency conversion rates for more tips.
+:::info
+Market Tracking is the user-facing name for automated rate management.
+:::
+
+For a deeper walkthrough, see [Automated Rate Management (Market Tracking)](market-tracking-arm.md).
 
 ![Provide Step 11](/img/provide-liquidity/ProvideStep11.png)
 
@@ -161,7 +168,8 @@ If all details are correct you can continue with your transaction!
   - Total amount
   - Remaining balance
   - Accepted currencies/platforms
-  - Current status  
+  - Current status
+  - Whether the deposit is using **Fixed**, **Market Tracking**, or **Delegated** rate management
 
 ![Provide Step 17](/img/provide-liquidity/ProvideStep17.png)
 ![Provide Step 17a](/img/provide-liquidity/ProvideStep17a.png)
@@ -176,6 +184,8 @@ If all details are correct you can continue with your transaction!
 - Check the **Spread** column in the Liquidity tab  
 - Lower spreads (0.5–1%) = faster fills, less profit  
 - Higher spreads (1–3%) = slower fills, more profit  
+- In Market Tracking mode, the spread is applied on top of the live market rate.
+- In Delegated mode, the vault sets the active rate but your floor still protects you.
 
 ### Security Best Practices
 
@@ -190,4 +200,4 @@ If all details are correct you can continue with your transaction!
 - Deposit not appearing? Refresh or reconnect wallet  
 - Still stuck? Join [Peer Telegram](https://t.me/+XDj9FNnW-xs5ODNl) for help  
 
-➡️ _Next: [How to Update USDC Conversion Rates](update-usdc-rates.md)_
+➡️ _Next: [Automated Rate Management (Market Tracking)](market-tracking-arm.md)_

--- a/guides/for-sellers/update-usdc-rates.md
+++ b/guides/for-sellers/update-usdc-rates.md
@@ -5,7 +5,12 @@ title: How to Update USDC Conversion Rates
 
 # How to Update USDC Conversion Rates
 
-After creating your deposit in ZKP2P, you may need to adjust your conversion rates to stay competitive or respond to market changes. This guide walks you through how to update your FX rates for existing deposits.
+After creating your deposit on Peer, you may want to update how each payment pair is priced. This guide covers both direct rate modes you control yourself:
+
+- **Fixed Rate**: you set the exact price.
+- **Market Tracking**: you set a spread above live FX and can keep an optional floor.
+
+If your deposit is **Delegated**, the active rate comes from the vault. You can still update your floor, but you cannot edit the vault-managed rate from the deposit itself.
 
 ### Step 1: Navigate to Your Deposit Details
 
@@ -41,10 +46,22 @@ In the modal, you'll see:
 
 - Platform (e.g., Revolut)  
 - Currency (e.g., GBP)  
-- Current Rate (e.g., 0.8)  
-- **New Conversion Rate** input  
+- A rate mode selector: **Fixed Rate** or **Market Tracking**
+- Current rate state for the pair
 
-Enter your new rate — e.g., changing **0.8 → 0.795** for GBP.
+If you choose **Fixed Rate**:
+
+- Enter a new direct rate such as `0.795`
+
+If you choose **Market Tracking**:
+
+- Enter a spread percentage such as `1.00%`
+- Optionally enter a floor if you want downside protection
+- Peer resolves the active rate as the higher of your floor and the live market rate plus spread
+
+:::info
+For oracle-backed pairs, a stale or invalid oracle quote halts that pair until fresh market data is available. Your deposit remains intact, but that payment-method and currency pair stops quoting until the oracle recovers.
+:::
 
 ![CR Step 4](/img/conversion-rate/CRStep4.png)  
 
@@ -78,6 +95,7 @@ Enter your new rate — e.g., changing **0.8 → 0.795** for GBP.
 - **Lower spreads** (0.5–1%) = faster sales, lower margin  
 - **Higher spreads** (1–3%) = higher margin, slower sales  
 - Balance depends on your strategy  
+- Market Tracking is better when you want to stay close to live FX without constant manual edits.
 
 ### Monitor Performance
 
@@ -93,4 +111,4 @@ After updating rates:
 - Rare currencies might require more competitive rates  
 - Optimize for each currency independently  
 
-➡️ _Next: [Handling Manual Releases as a Seller](manual-releases.md)_
+➡️ _Next: [How to Delegate a Deposit to a Vault](delegate-to-a-vault.md)_

--- a/protocol-sidebars.js
+++ b/protocol-sidebars.js
@@ -55,8 +55,12 @@ module.exports = {
               type: 'category',
               label: 'Escrow',
               link: { type: 'doc', id: 'v2/smart-contracts/escrow/index' },
-              items: ['v2/smart-contracts/escrow/v2-iescrow'],
+              items: [
+                'v2/smart-contracts/escrow/v2-iescrow',
+                'v2/smart-contracts/escrow/rate-management',
+              ],
             },
+            'v2/smart-contracts/rate-manager-v1',
             'v2/smart-contracts/v2-ipaymentverifier',
             'v2/smart-contracts/v2-deployments',
           ],

--- a/protocol/v2/smart-contracts/escrow/iescrow.md
+++ b/protocol/v2/smart-contracts/escrow/iescrow.md
@@ -1,148 +1,109 @@
 ---
 id: v2-iescrow
-title: IEscrow
+title: IEscrow and IEscrowV2
 ---
 
-The IEscrow interface defines the data structures and function signatures used by the Escrow contract. It helps external contracts and interfaces interact with the escrow in a standardized manner.
+`IEscrow` is the base escrow interface. `IEscrowV2` extends it with native oracle-backed ARM and delegated rate management.
 
-``` 
-interface IEscrow {
-    
-    /* ============ Structs ============ */
+If you are integrating V2 rate logic, use `IEscrowV2`.
 
-    struct Range {
-        uint256 min;  // Minimum value
-        uint256 max;  // Maximum value
-    }
+## `IEscrow` base interface
 
-    struct Deposit {
-        address depositor;                          
-        IERC20 token;                               
-        uint256 amount;                             
-        Range intentAmountRange;                    
-        bool acceptingIntents;                      
-        uint256 remainingDeposits;                  
-        uint256 outstandingIntentAmount;            
-        bytes32[] intentHashes;                     
-    }
+The shared `IEscrow` surface includes:
 
-    struct Currency {
-        bytes32 code;                // keccak256 hash of the currency code
-        uint256 conversionRate;      // Conversion rate of deposit token to fiat currency
-    }
+- deposit structs and view helpers
+- payment-method and currency listing
+- lock / unlock hooks used by the orchestrator
+- deposit admin functions such as delegates, retain-on-empty, and intent ranges
 
-    struct DepositVerifierData {
-        address intentGatingService; // Optional gating service for verifying off-chain eligibility
-        string payeeDetails;         // Payee details (hash or raw) that the verifier can parse
-        bytes data;                  // Additional data needed for payment verification
-    }
+Important base structs:
 
-    struct Intent {
-        address owner;               
-        address to;                  
-        uint256 depositId;           
-        uint256 amount;             
-        uint256 timestamp;           
-        address paymentVerifier;     
-        bytes32 fiatCurrency;        
-        uint256 conversionRate;      
-    }
+```solidity
+struct Range {
+    uint256 min;
+    uint256 max;
+}
 
-    struct VerifierDataView {
-        address verifier;
-        DepositVerifierData verificationData;
-        Currency[] currencies;
-    }
+struct Deposit {
+    address depositor;
+    address delegate;
+    IERC20 token;
+    Range intentAmountRange;
+    bool acceptingIntents;
+    uint256 remainingDeposits;
+    uint256 outstandingIntentAmount;
+    address intentGuardian;
+    bool retainOnEmpty;
+}
 
-    struct DepositView {
-        uint256 depositId;
-        Deposit deposit;
-        uint256 availableLiquidity;  
-        VerifierDataView[] verifiers;
-    }
-
-    struct IntentView {
-        bytes32 intentHash;
-        Intent intent;
-        DepositView deposit;
-    }
-
-    function getDepositFromIds(uint256[] memory _depositIds) external view returns (DepositView[] memory depositArray);
-} 
+struct Currency {
+    bytes32 code;
+    uint256 minConversionRate;
+}
 ```
 
-### Structs
+## `IEscrowV2` additions
 
--   Range Defines a minimum and maximum value. Used for `intentAmountRange`.
+V2 adds two new pricing concepts.
 
--   Deposit Describes all state and configuration data for a given deposit:
+### Oracle-backed ARM
 
-    -   `address depositor` -- Who created the deposit.
+```solidity
+struct OracleRateConfig {
+    address adapter;
+    bytes adapterConfig;
+    uint16 spreadBps;
+    uint32 maxStaleness;
+}
+```
 
-    -   `IERC20 token` -- Which token (ERC-20) is deposited.
+The V2 `Currency` struct becomes:
 
-    -   `uint256 amount` -- How many tokens are locked in escrow.
+```solidity
+struct Currency {
+    bytes32 code;
+    uint256 minConversionRate;
+    OracleRateConfig oracleRateConfig;
+}
+```
 
-    -   `Range intentAmountRange` -- The minimum and maximum each intent can claim.
+### Delegated rate management
 
-    -   `bool acceptingIntents` -- Whether new intents can be created for this deposit.
+```solidity
+struct RateManagerConfig {
+    address rateManager;
+    bytes32 rateManagerId;
+}
+```
 
-    -   `uint256 remainingDeposits` -- The current unclaimed amount.
+This is stored per deposit and points to the external `IRateManager` implementation that should supply delegated tuple rates.
 
-    -   `uint256 outstandingIntentAmount` -- Total amount locked by open/active intents.
+## V2-only functions
 
-    -   `bytes32[] intentHashes` -- An array of active intent identifiers.
+`IEscrowV2` adds:
 
--   Currency
+- `setOracleRateConfig`
+- `setOracleRateConfigBatch`
+- `removeOracleRateConfig`
+- `setRateManager`
+- `clearRateManager`
+- `getDepositOracleRateConfig`
+- `getDepositRateManager`
+- `getEffectiveRate`
+- `getManagerFee`
 
-    -   `bytes32 code` -- The currency code hashed via keccak256 (e.g. `"USD" -> keccak256("USD")`).
+## V2-only events
 
-    -   `uint256 conversionRate` -- Conversion between deposit token and this currency.
+`IEscrowV2` also adds:
 
--   DepositVerifierData
+- `DepositOracleRateConfigSet`
+- `DepositOracleRateConfigRemoved`
+- `DepositRateManagerSet`
+- `DepositRateManagerCleared`
 
-    -   `address intentGatingService` -- Optional gating service that signs off on user eligibility for an intent.
+## When to use which interface
 
-    -   `string payeeDetails` -- The string that identifies the payee or payee details.
+- Use `IEscrow` if you only need generic deposit custody and lock/unlock behavior.
+- Use `IEscrowV2` if you need automated rate management, delegated rate management, or effective-rate resolution.
 
-    -   `bytes data` -- Additional proof or attestation data required for the payment verifier.
-
--   Intent
-
-    -   `address owner` -- The address that initiated the intent (the potential off-chain payer).
-
-    -   `address to` -- Address that will receive on-chain funds if the intent is fulfilled.
-
-    -   `uint256 depositId` -- Reference to which deposit this intent targets.
-
-    -   `uint256 amount` -- Amount of the deposit's token to be claimed.
-
-    -   `uint256 timestamp` -- Block timestamp when the intent was created.
-
-    -   `address paymentVerifier` -- Which verifier is used to check off-chain payment.
-
-    -   `bytes32 fiatCurrency` -- The keccak256 hash of the off-chain currency code (e.g., `USD`).
-
-    -   `uint256 conversionRate` -- The rate used for off-chain-to-on-chain value conversion.
-
--   VerifierDataView
-
-    -   Binds a verifier address to its DepositVerifierData and an array of Currency structures.
-
--   DepositView
-
-    -   `uint256 depositId`
-
-    -   `Deposit deposit` -- The core deposit data.
-
-    -   `uint256 availableLiquidity` -- The effective unclaimed deposit (accounting for prunable/expired intents).
-
-    -   `VerifierDataView[] verifiers` -- An array of verifiers and their supported currencies.
-
--   IntentView
-
-    -   `bytes32 intentHash` -- Unique identifier for the intent.
-
-    -   `Intent intent` -- The Intent struct.
-
-    -   `DepositView deposit` -- Information about the deposit that the intent is targeting.
+For resolution behavior, see [Escrow Rate Management](rate-management.md).

--- a/protocol/v2/smart-contracts/escrow/index.md
+++ b/protocol/v2/smart-contracts/escrow/index.md
@@ -2,407 +2,125 @@
 title: Escrow
 ---
 
-## Overview
+# EscrowV2
 
-The Escrow contract allows users to lock ERC-20 tokens in order to receive off-chain payments. Users deposit tokens specifying:
+EscrowV2 is the liquidity and pricing core for V2 off-ramping.
 
-- Which off-chain payment verifiers they accept.
-- Conversion rates for various fiat currencies.
-- A gating service (optional) that can sign a user's intent to claim funds.
+It is responsible for:
 
-When a taker signals an intent to pay off-chain, they specify how many tokens they want to claim and through which payment verifier. Upon proving the off-chain payment has occurred (by calling `fulfillIntent`), the escrow releases the on-chain tokens to the taker (minus applicable fees).
+- holding maker funds
+- storing supported payment methods and fiat currencies
+- enforcing tuple-level rate controls
+- locking and unlocking liquidity for intents
+- exposing delegated rate manager assignments
 
----
+EscrowV2 is also where automated rate management lives. There is no separate ARM contract.
 
-## Constants
+## Deposit model
 
-- `uint256 internal constant PRECISE_UNIT = 1e18;`
-- `uint256 constant CIRCOM_PRIME_FIELD = ...;`
-- `uint256 constant MAX_SUSTAINABILITY_FEE = 5e16; // 5%`
+Each deposit stores:
 
----
+- `depositor`: the owner of the funds
+- `delegate`: an optional config delegate that can manage the deposit on the owner's behalf
+- `intentAmountRange`: min and max intent size
+- `acceptingIntents`
+- `remainingDeposits`
+- `outstandingIntentAmount`
+- `intentGuardian`
+- `retainOnEmpty`
 
-## State Variables
+Each supported payment-method and currency tuple stores:
 
-- `uint256 public immutable chainId;`  
-  The chain ID where this contract is deployed.
+- a fixed `minConversionRate`
+- an optional `OracleRateConfig`
+- an optional delegated manager assignment at the deposit level
 
-- `mapping(address => uint256[]) public accountDeposits;`  
-  Which deposits belong to a given address.
+:::note
+`delegate` and delegated rate management are different concepts. `delegate` is a deposit admin role. Delegated rate management is a pricing relationship to an external `IRateManager`.
+:::
 
-- `mapping(address => bytes32) public accountIntent;`  
-  Tracks a single active intent for each address.
+## Key write functions
 
-- `mapping(uint256 => mapping(address => DepositVerifierData)) public depositVerifierData;`  
-  Links a deposit ID + verifier to the relevant verification data (e.g., payee details).
+### Deposit lifecycle
 
-- `mapping(uint256 => address[]) public depositVerifiers;`  
-  Lists all verifiers associated with a deposit.
+- `createDeposit`
+- `depositTo`
+- `addFunds`
+- `removeFunds`
+- `withdrawDeposit`
+- `setAcceptingIntents`
+- `setIntentRange`
+- `setRetainOnEmpty`
+- `setDelegate`
+- `removeDelegate`
 
-- `mapping(uint256 => mapping(address => mapping(bytes32 => uint256))) public depositCurrencyConversionRate;`  
-  For a given deposit ID and verifier, maps fiat currency -> conversion rate.
+### Payment-method and currency config
 
-- `mapping(uint256 => mapping(address => bytes32[])) public depositCurrencies;`  
-  For a given deposit ID and verifier, stores an array of fiat currencies.
+- `addPaymentMethods`
+- `setPaymentMethodActive`
+- `addCurrencies`
+- `deactivateCurrency`
 
-- `mapping(uint256 => Deposit) public deposits;`  
-  The core deposit data.
+### ARM and delegated pricing
 
-- `mapping(bytes32 => Intent) public intents;`  
-  All signaled intents (by their intent hash).
+- `setCurrencyMinRate`
+- `setOracleRateConfig`
+- `setOracleRateConfigBatch`
+- `removeOracleRateConfig`
+- `setRateManager`
+- `clearRateManager`
 
-- Whitelist / Governance  
-  - `bool public acceptAllPaymentVerifiers;`  
-  - `mapping(address => bool) public whitelistedPaymentVerifiers;`  
-  - `mapping(address => uint256) public paymentVerifierFeeShare;`
+The detailed rate-resolution rules are documented in [Escrow Rate Management](rate-management.md).
 
-- `uint256 public intentExpirationPeriod;`  
-  After which an intent is considered expired.
+## Intent liquidity flow
 
-- `uint256 public sustainabilityFee;`  
-  Fee (in `PRECISE_UNIT` terms) taken from each successful intent fulfillment.
+EscrowV2 itself does not verify offchain payment proofs. The Orchestrator and payment verifiers do that.
 
-- `address public sustainabilityFeeRecipient;`  
-  Where the sustainability fee is sent.
+EscrowV2 handles the liquidity side:
 
-- `uint256 public depositCounter;`  
-  Incremented to create unique deposit IDs.
+- `lockFunds`: reserves deposit liquidity for a signaled intent
+- `unlockFunds`: releases liquidity back to the deposit on cancel or prune
+- `unlockAndTransferFunds`: releases fulfilled liquidity to the orchestrator for payout
+- `extendIntentExpiry`: extends a lock via the configured guardian flow
 
----
+## Rate resolution summary
 
-## Constructor
+For any tuple, EscrowV2 computes the effective rate in this order:
 
-```
-constructor(
-    address _owner,
-    uint256 _chainId,
-    uint256 _intentExpirationPeriod,
-    uint256 _sustainabilityFee,
-    address _sustainabilityFeeRecipient
-) Ownable() { ... }
-```
+1. Resolve the escrow floor from fixed floor and optional oracle-backed spread.
+2. If that floor is zero, the tuple is halted.
+3. If no rate manager is assigned, return the escrow floor.
+4. If delegated, ask the manager for a tuple rate.
+5. Return `max(managerRate, escrowFloor)`, subject to the manager-disabled and manager-revert rules.
 
-Parameters:
+## Read helpers
 
-- `_owner`: The address to set as the contract owner (can pause, unpause, and manage verifiers).
-- `_chainId`: The chain ID for which this escrow is valid.
-- `_intentExpirationPeriod`: Time (in seconds) after which an open intent can be pruned.
-- `_sustainabilityFee`: Percentage (in 1e18 precision) charged upon successful intent fulfillment.
-- `_sustainabilityFeeRecipient`: Address to receive the sustainability fees.
+Useful view methods:
 
-Transfers ownership to `_owner` and sets initial contract state.
+- `getDeposit`
+- `getDepositPaymentMethods`
+- `getDepositCurrencies`
+- `getDepositCurrencyMinRate`
+- `getDepositOracleRateConfig`
+- `getDepositRateManager`
+- `getEffectiveRate`
+- `getManagerFee`
+- `getExpiredIntents`
 
----
+For interface details, see [IEscrow and IEscrowV2](iescrow.md).
 
-## External Functions
+## Fees
 
-### createDeposit
+EscrowV2 participates in three distinct fee surfaces:
 
-```
-function createDeposit(
-    IERC20 _token,
-    uint256 _amount,
-    Range calldata _intentAmountRange,
-    address[] calldata _verifiers,
-    DepositVerifierData[] calldata _verifierData,
-    Currency[][] calldata _currencies
-)
-    external
-    whenNotPaused
-```
+- protocol sustainability fee
+- payment verifier fee share
+- delegated manager fee, exposed via `getManagerFee`
 
-Description: Deposits `_amount` of `_token` into escrow. You specify:
+Manager fees are applied by the orchestrator on release. The manager fee is not baked into the gross `getEffectiveRate` result.
 
-- A range of intent sizes (`_intentAmountRange`).
-- Which verifiers (`_verifiers`) the deposit will accept.
-- Gating + payee details for each verifier (`_verifierData`).
-- Which currencies (and rates) each verifier can handle (`_currencies`).
+## Related pages
 
-Requirements:
-
-- User must have approved this contract to transfer `_amount` of `_token`.
-- The deposit is unique (each call yields a new `depositId`).
-- `_amount` must be >= `min` of `_intentAmountRange`.
-- `_verifiers` length must match `_verifierData` and `_currencies` length.
-- Each verifier must be whitelisted or `acceptAllPaymentVerifiers` must be `true`.
-- Each currency's `conversionRate` must be > 0.
-
-Effects:
-
-- Increments `depositCounter`.
-- Stores the deposit data.
-- Locks the tokens in this contract.
-- Emits `DepositReceived` and `DepositVerifierAdded` (and `DepositCurrencyAdded`) events.
-
----
-
-### signalIntent
-
-```
-function signalIntent(
-    uint256 _depositId,
-    uint256 _amount,
-    address _to,
-    address _verifier,
-    bytes32 _fiatCurrency,
-    bytes calldata _gatingServiceSignature
-)
-    external
-    whenNotPaused
-```
-
-Description: A taker declares an intent to pay the deposit's off-chain counterpart. This:
-
-- Ensures the deposit is still `acceptingIntents`.
-- Validates `_amount` against deposit's range.
-- Optionally checks a gating service signature.
-- Reserves `_amount` from the deposit's `remainingDeposits`.
-- Records a new `Intent` in `intents`.
-
-Requirements:
-
-- Caller must not have another active `Intent` (`accountIntent[msg.sender] == 0`).
-- `_amount` is within the deposit's `intentAmountRange`.
-- `_fiatCurrency` is recognized in `depositCurrencyConversionRate[_depositId][_verifier]`.
-
-Effects:
-
-- May prune expired intents if liquidity is insufficient.
-- Emits `IntentSignaled` upon success.
-
----
-
-### cancelIntent
-
-```
-function cancelIntent(bytes32 _intentHash) external
-```
-
-Description: Allows the intent owner to cancel an intent. This frees up the escrowed amount. Reverts if `msg.sender` is not the intent owner.
-
----
-
-### fulfillIntent
-
-```
-function fulfillIntent(bytes calldata _paymentProof, bytes32 _intentHash) external whenNotPaused
-```
-
-Description: Attempts to prove that the off-chain payment has been made according to the associated payment verifier. On success:
-
-- The escrowed tokens are transferred to the specified `to` address.
-- Fees are taken out for sustainability and optionally the payment verifier.
-
-Parameters:
-
-- `_paymentProof` -- The proof data for verifying off-chain payment (e.g., TLSNotary, ZK, etc.).
-- `_intentHash` -- The ID of the signaled intent.
-
-Reverts if:
-
-- The verifier check fails.
-- The `_intentHash` does not match the proof's extracted intent hash.
-
-Emits:
-
-- `IntentFulfilled` event.
-
----
-
-### releaseFundsToPayer
-
-```
-function releaseFundsToPayer(bytes32 _intentHash) external
-```
-
-Description: Allows the deposit owner (not the intent owner) to push funds to the off-chain payer's `to` address, effectively acknowledging the payment or an alternative arrangement.
-
-Effects:
-
-- Removes the intent from state.
-- Transfers tokens to the `intent.owner` or `intent.to`.
-- Emits `IntentFulfilled` event with zero verifier address.
-
----
-
-### updateDepositConversionRate
-
-```
-function updateDepositConversionRate(
-    uint256 _depositId,
-    address _verifier,
-    bytes32 _fiatCurrency,
-    uint256 _newConversionRate
-)
-    external
-    whenNotPaused
-```
-
-Description: The depositor can adjust the deposit's conversion rate for a specific currency and verifier. Only future intents will be affected; existing ones store the old rate.
-
----
-
-### withdrawDeposit
-
-```
-function withdrawDeposit(uint256 _depositId) external
-```
-
-Description: Withdraws any unencumbered tokens from the deposit. Prunes any expired intents (making more tokens claimable). If no tokens remain (and no open intents), the deposit is fully closed and removed.
-
----
-
-## Governance Functions
-
-### addWhitelistedPaymentVerifier
-
-```
-function addWhitelistedPaymentVerifier(address _verifier, uint256 _feeShare) external onlyOwner
-```
-
-Adds a payment verifier to the whitelist, with a certain `_feeShare`.
-
-### removeWhitelistedPaymentVerifier
-
-```
-function removeWhitelistedPaymentVerifier(address _verifier) external onlyOwner
-```
-
-Removes a verifier from the whitelist.
-
-### updatePaymentVerifierFeeShare
-
-```
-function updatePaymentVerifierFeeShare(address _verifier, uint256 _feeShare) external onlyOwner
-```
-
-Updates the fee share for a given whitelisted verifier.
-
-### updateAcceptAllPaymentVerifiers
-
-```
-function updateAcceptAllPaymentVerifiers(bool _acceptAllPaymentVerifiers) external onlyOwner
-```
-
-Toggles whether any verifier address can be used (bypassing the whitelist).
-
-### setSustainabilityFee
-
-```
-function setSustainabilityFee(uint256 _fee) external onlyOwner
-```
-
-Sets the global sustainability fee (max 5%). Fee is taken upon intent fulfillment.
-
-### setSustainabilityFeeRecipient
-
-```
-function setSustainabilityFeeRecipient(address _feeRecipient) external onlyOwner
-```
-
-Sets the address receiving protocol fees.
-
-### setIntentExpirationPeriod
-
-```
-function setIntentExpirationPeriod(uint256 _intentExpirationPeriod) external onlyOwner
-```
-
-Updates how long an intent remains valid before it can be pruned.
-
-### pauseEscrow / unpauseEscrow
-
-```
-function pauseEscrow() external onlyOwner
-function unpauseEscrow() external onlyOwner
-```
-
-Pauses or unpauses the contract's core functions:
-
-- Paused: Creates deposit, updates conversion rate, signals/fulfills intent are disabled.
-- Unpaused: Resumes all functionalities.
-
----
-
-## External View Functions
-
-### getPrunableIntents
-
-```
-function getPrunableIntents(uint256 _depositId)
-    external
-    view
-    returns (bytes32[] memory prunableIntents, uint256 reclaimedAmount);
-```
-
-Returns a list of expired (prunable) intent hashes for a deposit and the total amount they occupy.
-
-### getDeposit
-
-```
-function getDeposit(uint256 _depositId)
-    public
-    view
-    returns (DepositView memory depositView);
-```
-
-Returns a DepositView, including:
-
-- The deposit details.
-- Available liquidity (accounting for expired intents).
-- Associated verifiers/currency data.
-
-### getAccountDeposits
-
-```
-function getAccountDeposits(address _account)
-    external
-    view
-    returns (DepositView[] memory depositArray);
-```
-
-Returns the set of deposits belonging to `_account`.
-
-### getDepositFromIds
-
-```
-function getDepositFromIds(uint256[] memory _depositIds)
-    external
-    view
-    returns (DepositView[] memory depositArray);
-```
-
-Returns the `DepositView[]` for a given list of deposit IDs (part of IEscrow interface).
-
-### getIntent
-
-```
-function getIntent(bytes32 _intentHash)
-    public
-    view
-    returns (IntentView memory intentView);
-```
-
-Provides the IntentView, linking the intent to its deposit.
-
-### getIntents
-
-```
-function getIntents(bytes32[] calldata _intentHashes)
-    external
-    view
-    returns (IntentView[] memory intentArray);
-```
-
-Batch retrieval of multiple intents.
-
-### getAccountIntent
-
-```
-function getAccountIntent(address _account)
-    external
-    view
-    returns (IntentView memory intentView);
-```
-
-Returns the active intent (if any) for a given account.
+- [Escrow Rate Management](rate-management.md)
+- [RateManagerV1](../rate-manager-v1.md)
+- [IEscrow and IEscrowV2](iescrow.md)

--- a/protocol/v2/smart-contracts/escrow/rate-management.md
+++ b/protocol/v2/smart-contracts/escrow/rate-management.md
@@ -1,0 +1,161 @@
+---
+title: Escrow Rate Management
+---
+
+# Escrow Rate Management
+
+EscrowV2 combines two pricing layers:
+
+- tuple-level floor management inside EscrowV2
+- optional deposit-level delegated pricing through `IRateManager`
+
+This page documents how those layers compose.
+
+## Tuple-level state
+
+Every `(depositId, paymentMethod, currency)` tuple may have:
+
+- a fixed floor in `depositCurrencyMinRate`
+- an optional `OracleRateConfig`
+
+The `OracleRateConfig` struct is:
+
+```solidity
+struct OracleRateConfig {
+    address adapter;
+    bytes adapterConfig;
+    uint16 spreadBps;
+    uint32 maxStaleness;
+}
+```
+
+If `adapter == address(0)`, oracle-backed pricing is disabled for that tuple.
+
+## Fixed floor writes
+
+`setCurrencyMinRate` updates the depositor floor for a listed tuple.
+
+Important behavior:
+
+- zero is allowed
+- zero disables the fixed floor
+- zero does not remove an oracle config
+
+## Oracle-backed ARM writes
+
+EscrowV2 exposes:
+
+- `setOracleRateConfig`
+- `setOracleRateConfigBatch`
+- `removeOracleRateConfig`
+
+The adapter returns a market quote. EscrowV2 applies `spreadBps` on top of that quote and rounds up.
+
+## Escrow floor resolution
+
+Internally, EscrowV2 computes:
+
+```text
+spreadRate = oracleQuoteWithSpread
+escrowFloor = max(fixedRate, spreadRate)
+```
+
+But there is one exception:
+
+If an oracle is configured and `spreadRate == 0`, EscrowV2 returns `0` for the tuple instead of falling back to the fixed floor.
+
+## Oracle halt conditions
+
+An oracle-backed tuple halts when the adapter resolves an unusable quote, including:
+
+- invalid quote flag
+- zero market rate
+- zero update timestamp
+- future-dated update timestamp
+- quote older than `maxStaleness`
+- adapter call revert
+
+When that happens:
+
+- `_getDepositCurrencyMinRate` returns `0`
+- `getEffectiveRate` returns `0`
+- the tuple is disabled until the oracle recovers or the config is removed
+
+## Delegated manager assignment
+
+At the deposit level, EscrowV2 stores:
+
+```solidity
+struct RateManagerConfig {
+    address rateManager;
+    bytes32 rateManagerId;
+}
+```
+
+The depositor can:
+
+- opt in with `setRateManager`
+- remove delegation with `clearRateManager`
+
+Only the deposit owner can set or clear a rate manager. The deposit `delegate` role cannot do this.
+
+When opting in, EscrowV2 immediately calls:
+
+```solidity
+IRateManager(_rateManager).onDepositOptIn(_depositId, _rateManagerId);
+```
+
+If that callback reverts, the delegation fails.
+
+## `getEffectiveRate` precedence
+
+`getEffectiveRate` resolves the final gross tuple rate with the following rules:
+
+1. Compute `escrowFloor`.
+2. If `escrowFloor == 0`, return `0`.
+3. If there is no manager, return `escrowFloor`.
+4. If there is a manager, call `IRateManager.getRate(...)`.
+5. If the manager returns `0`, return `0`.
+6. If the manager reverts, return `escrowFloor`.
+7. Otherwise, return `max(delegatedRate, escrowFloor)`.
+
+This gives EscrowV2 three important safety properties:
+
+- manager quotes cannot undercut the deposit floor
+- manager outages fail safe to the escrow floor
+- oracle-halted tuples stay halted even when delegated
+
+## Manager fees
+
+EscrowV2 also exposes:
+
+```solidity
+function getManagerFee(uint256 _depositId)
+    external
+    view
+    returns (address recipient, uint256 fee);
+```
+
+If the manager call reverts, EscrowV2 fails safe to `(address(0), 0)`.
+
+This fee is used by the orchestrator during payout. It does not change the gross value returned by `getEffectiveRate`.
+
+## Indexer alignment
+
+The indexer mirrors these rules onto `MethodCurrency`:
+
+- `minConversionRate`
+- `managerRate`
+- `managerFee`
+- `conversionRate`
+- `takerConversionRate`
+- `rateSource`
+
+`rateSource` can be:
+
+- `MANAGER`
+- `ORACLE`
+- `ESCROW_FLOOR`
+- `MANAGER_DISABLED`
+- `ORACLE_HALTED`
+- `NO_FLOOR`

--- a/protocol/v2/smart-contracts/index.md
+++ b/protocol/v2/smart-contracts/index.md
@@ -2,24 +2,47 @@
 title: Smart Contracts
 ---
 
-# Smart Contracts
+# V2 Smart Contracts
 
-[](https://docs.peer.xyz/developer/smart-contracts#escrow)
+Protocol V2 off-ramping is built around EscrowV2 custody, Orchestrator-mediated intent execution, payment verifier contracts, and optional delegated rate managers.
 
-## Escrow
+## Main components
 
-The `Escrow` contract is designed to orchestrate the interaction between different actors in the ecosystem. It manages user registrations, deposits, and transaction intents, and employs Zero-Knowledge Proofs for validation purposes. Additionally, it provides mechanisms for dispute resolution, instant verification, and governance controls to maintain system integrity and ensure a secure and trustless environment for P2P transactions.
+### EscrowV2
 
-[](https://docs.peer.xyz/developer/smart-contracts#verifiers)
+EscrowV2 is the core liquidity contract. It:
 
-## Verifiers
+- holds maker funds
+- stores payment-method and currency tuples
+- enforces fixed floors and oracle-backed ARM floors
+- optionally delegates tuple pricing to a rate manager
+- locks and unlocks funds for intents
 
-The Verifiers are contracts designed to verify and process on-chain proof of off-chain transactions, ensuring they conform to specified protocols. It validates various elements of the transactions including transaction amount, timestamp, recipient ID and intent hash. Through these validations, it facilitates secure transaction processing in the system.
+Start with [Escrow](escrow/index.md).
 
-Verifiers conform to a `BasePaymentVerifier` [specification](https://github.com/zkp2p/zkp2p-v2-contracts/tree/main/contracts/verifiers/BaseVerifiers).
+### RateManagerV1
 
-[](https://docs.peer.xyz/developer/smart-contracts#nullifier-registry)
+`RateManagerV1` is the reference delegated rate management contract on `main`.
 
-## Nullifier Registry
+It is a pure rate registry. It does not custody funds and it does not enforce deposit floors. EscrowV2 does that when resolving the effective rate.
 
-The `NullifierRegistry` is a smart contract that records unique identifiers (nullifiers) to prevent duplication in actions like user registrations. It controls writer permissions for adding nullifiers and offers transparent logging of these actions through emitted events.
+See [RateManagerV1](rate-manager-v1.md).
+
+### Payment verifiers
+
+Payment verifiers validate offchain payment proofs during fulfillment.
+
+See [IPaymentVerifier](ipaymentverifier.md).
+
+### Deployments
+
+Contract addresses for supported environments are listed in [Deployments](deployments.md).
+
+## ARM and DRM in the V2 stack
+
+V2 rate management has two layers:
+
+- `Automated Rate Management`: tuple-level fixed floors plus optional oracle-backed spread config inside EscrowV2
+- `Delegated Rate Management`: deposit-level assignment to an external `IRateManager`
+
+The detailed resolution rules are documented in [Escrow Rate Management](escrow/rate-management.md).

--- a/protocol/v2/smart-contracts/rate-manager-v1.md
+++ b/protocol/v2/smart-contracts/rate-manager-v1.md
@@ -1,0 +1,119 @@
+---
+title: RateManagerV1
+---
+
+# RateManagerV1
+
+`RateManagerV1` is the reference delegated rate management contract on `main`.
+
+It is intentionally narrow:
+
+- it stores manager-owned tuple rates
+- it stores manager fee and metadata
+- it validates opt-in rules like `minLiquidity`
+- it does not custody deposits
+- it does not enforce depositor floors
+
+EscrowV2 remains the final authority on the effective quote.
+
+## Core config
+
+Each manager id stores:
+
+```solidity
+struct RateManagerConfig {
+    address manager;
+    address feeRecipient;
+    uint256 maxFee;
+    uint256 fee;
+    uint256 minLiquidity;
+    string name;
+    string uri;
+}
+```
+
+Rates are stored per manager id, payment method, and fiat currency.
+
+## Fee limits
+
+`RateManagerV1` enforces:
+
+```solidity
+uint256 public constant GLOBAL_MAX_MANAGER_FEE = 5e16; // 5%
+```
+
+At creation time:
+
+- `maxFee` must be `<= 5%`
+- `fee` must be `<= maxFee`
+- nonzero `fee` requires a nonzero `feeRecipient`
+
+Later, `setFee` enforces the same `fee <= maxFee` rule.
+
+## Creation and admin
+
+Manager-side writes:
+
+- `createRateManager`
+- `setRateManagerConfig`
+- `setFee`
+- `setMinLiquidity`
+- `setRate`
+- `setRateBatch`
+
+The `manager` address is the only address allowed to mutate that manager id.
+
+`maxFee` is immutable after creation.
+
+## Opt-in callback
+
+EscrowV2 calls `onDepositOptIn` when a deposit delegates to a manager.
+
+`RateManagerV1` rejects opt-in when:
+
+- the calling escrow is not whitelisted in the escrow registry
+- the manager id does not exist
+- the deposit liquidity is below `minLiquidity`
+
+Liquidity is measured as:
+
+```text
+remainingDeposits + outstandingIntentAmount
+```
+
+This makes `minLiquidity` a deposit-entry requirement, not a runtime pricing formula.
+
+## View interface
+
+`RateManagerV1` implements `IRateManager`:
+
+- `getRate`
+- `getFee`
+- `isRateManager`
+- `onDepositOptIn`
+
+Additional convenience views:
+
+- `getRateManager`
+- `getManagerRate`
+
+## Escrow interaction
+
+`getRate` returns the manager-set tuple rate only.
+
+EscrowV2 decides how that rate is used:
+
+- if the manager rate is `0`, the delegated tuple is disabled
+- if the manager rate is below the deposit floor, the floor wins
+- if the manager call reverts, EscrowV2 falls back to the escrow floor
+
+That means `RateManagerV1` should be understood as a registry, not as a full quoting engine.
+
+## Product terminology
+
+Peer UI surfaces call these managers `vaults`.
+
+That is a product concept, not a distinct onchain contract type. Onchain, a vault is simply:
+
+- a `RateManagerV1` manager id, plus
+- one or more deposits delegated to it in EscrowV2


### PR DESCRIPTION
## Summary

This updates the docs site to properly document automated rate management, delegated rate management, and the current SDK surface that manages both. The user-facing seller guides now explain Market Tracking and vault delegation in the same terms used by the product, while the developer and protocol sections now describe the actual V2 contract and indexer behavior on `main`.

Before this change, the docs split was incomplete and in a few places materially stale. The seller docs did not explain the difference between fixed pricing, automated pricing, and delegated pricing well enough for operators to choose the right mode. The developer integration page still documented the old client shape and did not cover the current `Zkp2pClient`, the ARM write methods, the vault helpers, or the indexer read model that downstream apps actually consume. The V2 protocol docs were even further behind: the escrow pages still described older conversion-rate surfaces, did not capture EscrowV2 oracle-spread pricing, and did not explain how `RateManagerV1` interacts with EscrowV2 floor enforcement.

That gap matters to both users and integrators. Sellers need to understand that Market Tracking is automated rate management centered on user-controlled deposit floors and oracle-backed spread pricing. Vault operators and depositors need to understand that delegated rate management is a manager-controlled rate layer on top of those deposit floors, not a custody transfer. Integrators need to understand that the canonical read model now lives in the indexer `Deposit` and `MethodCurrency` entities, and that the effective-rate precedence in EscrowV2 is stricter than a simple fallback model because configured oracles can halt a tuple and delegated managers cannot undercut or revive that halted floor.

The root cause was that the docs had grown around earlier product and contract shapes while the live implementation evolved in `zkp2p-contracts`, `zkp2p-indexer`, and `zkp2p-clients`. I pulled the latest `main` for those repos and rewrote the relevant docs against the current source of truth instead of layering new copy onto the old pages. The new material now explicitly distinguishes the product term "vault" from the onchain reality of a `RateManager` contract plus delegated deposits, explains the oracle halt semantics in EscrowV2, documents the delegated-rate precedence rules, and updates the SDK examples to the real `Zkp2pClient` API and current indexer helper methods.

The concrete doc changes are:

- new seller guides for Market Tracking, creating a vault, and delegating a deposit to a vault
- seller guide updates so the core liquidity flow points users to fixed, automated, and delegated pricing paths explicitly
- a rewritten Offramp Integration page based on the current SDK
- new developer pages for automated rate management and delegated rate management
- a refreshed V2 smart-contract overview
- a rewritten EscrowV2 overview and interface page
- new protocol reference pages for Escrow rate management and `RateManagerV1`

## Validation

I validated the docs by running a full production build after installing the worktree dependencies with the pinned Yarn 3 CLI in a writable temp-home environment:

`HOME=/tmp/codex-home npm_config_cache=/tmp/.npm-cache npx -y @yarnpkg/cli-dist@3.6.4 install`

`HOME=/tmp/codex-home npm_config_cache=/tmp/.npm-cache npx -y @yarnpkg/cli-dist@3.6.4 build`

The build completed successfully and generated the static site.
