### PR TITLE
docs: refresh offramp integration and add ARM guides

### DIFF
--- a/developer-sidebars.js
+++ b/developer-sidebars.js
@@ -6,6 +6,7 @@ module.exports = {
       label: 'Onramp Integration',
     },
     { type: 'doc', id: 'offramp-integration', label: 'Offramp Integration' },
+    { type: 'doc', id: 'automated-rate-management', label: 'Automated Rate Management' },
     { type: 'doc', id: 'post-intent-hooks', label: 'Post‑Intent Hooks' },
     { type: 'doc', id: 'build-payment-integration', label: 'Build a Payment Integration' },
   ],

--- a/developer/CLAUDE.md
+++ b/developer/CLAUDE.md
@@ -7,7 +7,8 @@ Integration guides for developers building on ZKP2P.
 | Document | Audience | Integration Type |
 |----------|----------|------------------|
 | `integrate-zkp2p/integrate-redirect-onramp.md` | App developers | Embed fiat onramp in web apps |
-| `offramp-integration.md` | Liquidity providers | Manage USDC deposits for offramp |
+| `offramp-integration.md` | Liquidity providers | Manage USDC deposits with Zkp2pClient |
+| `automated-rate-management.md` | SDK integrators | Configure oracle-backed market tracking |
 | `post-intent-hooks.md` | Protocol developers | Custom fulfillment logic (Solidity) |
 | `build-new-provider.md` | Protocol developers | zkTLS provider templates (JSON) |
 
@@ -17,7 +18,8 @@ Integration guides for developers building on ZKP2P.
 developer/
 ├── integrate-zkp2p/
 │   └── integrate-redirect-onramp.md    # @zkp2p/sdk onramp
-├── offramp-integration.md              # OfframpClient SDK
+├── offramp-integration.md              # Zkp2pClient SDK
+├── automated-rate-management.md        # ARM tuple configuration
 ├── post-intent-hooks.md                # IPostIntentHook Solidity
 └── build-new-provider.md               # Provider JSON templates
 ```
@@ -26,7 +28,7 @@ developer/
 
 | Package | Purpose |
 |---------|---------|
-| `@zkp2p/sdk` | Main SDK (peerExtensionSdk, OfframpClient) |
+| `@zkp2p/sdk` | Main SDK (peerExtensionSdk, Zkp2pClient) |
 | `@zkp2p/providers` | Payment provider template definitions |
 
 ## Documentation Patterns

--- a/developer/automated-rate-management.md
+++ b/developer/automated-rate-management.md
@@ -1,0 +1,193 @@
+---
+id: automated-rate-management
+title: Automated Rate Management
+---
+
+# Automated Rate Management
+
+ARM (Automated Rate Management) is EscrowV2's oracle-backed pricing for deposit tuples.
+For each payment-method/currency pair, you can configure an oracle adapter and spread so rates track the market automatically.
+
+## Overview
+
+With ARM enabled for a tuple, EscrowV2 uses:
+
+- Depositor floor (`minConversionRate`)
+- Oracle-backed market rate with spread (`oracleRateConfig`)
+
+Effective floor behavior is:
+
+```text
+effectiveFloor = max(minConversionRate, oracleRateAfterSpread)
+```
+
+## Tuple-level config model
+
+`OracleRateConfig` on each tuple contains:
+
+- `adapter`: oracle adapter contract
+- `adapterConfig`: adapter-specific encoded config bytes
+- `spreadBps`: signed basis points (`50 = +0.50%`, `-50 = -0.50%`)
+- `maxStaleness`: allowed age of oracle data in seconds
+
+Precision/units:
+
+- USDC amounts: 6 decimals
+- Conversion rates: 18-decimal bigint
+- Spread: signed integer basis points
+
+## SDK writes
+
+### Resolve oracle config from SDK helpers
+
+```ts
+import {
+  Currency,
+  getSpreadOracleConfig,
+  CHAINLINK_ORACLE_ADAPTER,
+  PYTH_ORACLE_ADAPTER,
+  DEFAULT_ORACLE_MAX_STALENESS_SECONDS,
+} from '@zkp2p/sdk';
+
+const eurOracle = getSpreadOracleConfig(Currency.EUR);
+if (!eurOracle) throw new Error('No oracle config for EUR');
+const adapter = eurOracle.adapter; // CHAINLINK_ORACLE_ADAPTER or PYTH_ORACLE_ADAPTER
+const maxStaleness =
+  eurOracle.maxStaleness ?? DEFAULT_ORACLE_MAX_STALENESS_SECONDS;
+```
+
+### Set ARM config for one tuple
+
+```ts
+import {
+  Currency,
+  resolveFiatCurrencyBytes32,
+  getPaymentMethodsCatalog,
+  getSpreadOracleConfig,
+} from '@zkp2p/sdk';
+
+const methods = getPaymentMethodsCatalog(client.chainId, client.runtimeEnv);
+const paymentMethodHash = methods.wise.paymentMethodHash;
+const currencyHash = resolveFiatCurrencyBytes32(Currency.EUR);
+
+const oracle = getSpreadOracleConfig(Currency.EUR);
+if (!oracle) throw new Error('No oracle config for EUR');
+
+await client.setOracleRateConfig({
+  depositId: 1n,
+  paymentMethodHash,
+  currencyHash,
+  config: {
+    adapter: oracle.adapter,
+    adapterConfig: oracle.adapterConfig,
+    spreadBps: 50,
+    maxStaleness: 86_400,
+  },
+});
+```
+
+### Remove ARM config for one tuple
+
+```ts
+await client.removeOracleRateConfig({
+  depositId: 1n,
+  paymentMethodHash,
+  currencyHash,
+});
+```
+
+### Batch ARM config updates
+
+```ts
+await client.setOracleRateConfigBatch({
+  depositId: 1n,
+  paymentMethods: [paymentMethodHash],
+  currencies: [[currencyHash]],
+  configs: [[{
+    adapter: oracle.adapter,
+    adapterConfig: oracle.adapterConfig,
+    spreadBps: 25,
+    maxStaleness: 86_400,
+  }]],
+});
+```
+
+### Create deposit with ARM preconfigured
+
+`oracleRateConfig` can be included in `OnchainCurrencyEntry` via `currenciesOverride`.
+
+```ts
+import {
+  Currency,
+  resolveFiatCurrencyBytes32,
+  getSpreadOracleConfig,
+} from '@zkp2p/sdk';
+
+const eurOracle = getSpreadOracleConfig(Currency.EUR);
+if (!eurOracle) throw new Error('No oracle config for EUR');
+
+await client.createDeposit({
+  token: '0xUSDC_ADDRESS',
+  amount: 1_000_000000n,
+  intentAmountRange: { min: 10_000000n, max: 100_000000n },
+  processorNames: ['wise'],
+  depositData: [{ email: 'maker@example.com' }],
+  conversionRates: [[{ currency: Currency.EUR, conversionRate: '900000000000000000' }]],
+  paymentMethodsOverride: ['0xPAYMENT_METHOD_HASH'],
+  paymentMethodDataOverride: [{
+    intentGatingService: '0xGATING_SERVICE',
+    payeeDetails: '0xPAYEE_HASH',
+    data: '0x',
+  }],
+  currenciesOverride: [[{
+    code: resolveFiatCurrencyBytes32(Currency.EUR),
+    minConversionRate: 900_000_000_000_000_000n,
+    oracleRateConfig: {
+      adapter: eurOracle.adapter,
+      adapterConfig: eurOracle.adapterConfig,
+      spreadBps: 40,
+      maxStaleness: eurOracle.maxStaleness,
+    },
+  }]],
+});
+```
+
+## Oracle constants and feed maps
+
+The SDK exports:
+
+- `CHAINLINK_ORACLE_ADAPTER`
+- `PYTH_ORACLE_ADAPTER`
+- `DEFAULT_ORACLE_MAX_STALENESS_SECONDS` (`86400`)
+- `CHAINLINK_ORACLE_FEEDS`
+- `PYTH_ORACLE_FEEDS`
+- `encodeSpreadOracleAdapterConfig(...)`
+- `getSpreadOracleConfig(...)`
+
+## Indexer read model (`MethodCurrency`)
+
+`client.indexer.getDepositById(...)` and related methods return tuple rows with `rateSource`.
+Common values:
+
+- `ORACLE`: oracle-backed rate is active
+- `ESCROW_FLOOR`: escrow floor is active
+- `ORACLE_HALTED`: oracle configured but stale/invalid
+- `NO_FLOOR`: no usable floor/rate configured
+
+## Oracle halt semantics
+
+When oracle config exists but the oracle result is stale/invalid/zero/reverted, the tuple is halted.
+
+:::warning
+Oracle halt does **not** fall back to fixed floor automatically. The tuple pauses until oracle config is fixed or removed.
+:::
+
+Operationally, that means:
+
+- Effective rate becomes zero for matching
+- New orders for that tuple are blocked
+- Funds remain in the deposit
+
+## Next pages
+
+- [Back to Offramp Integration](offramp-integration.md)

--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -6,19 +6,27 @@ slug: /developer/offramp
 
 # Offramp Integration
 
-The ZKP2P Client SDK is a TypeScript SDK for liquidity providers who want to offer fiat off-ramp services on Base. Use it to create and manage USDC deposits, configure payment methods and currencies, and query on-chain state with RPC-first reads.
+`@zkp2p/sdk` gives liquidity providers a single `Zkp2pClient` for deposit creation, deposit management, and ARM tuple configuration.
+
+This page focuses on:
+
+- Creating and managing deposits
+- Managing tuple pricing with Fixed Rate and ARM (Market Tracking)
 
 ## Who is this for?
 
-This SDK is designed for liquidity providers (peers) who want to:
-- Create and manage USDC deposits that accept fiat payments
-- Configure payment methods, currencies, and conversion rates
-- Monitor deposit utilization and manage liquidity
-- Earn fees by providing off-ramp services
+This guide is for integrators building seller/offramp workflows that need to:
+
+- Create deposits
+- Configure payment methods and currencies
+- Manage fixed and oracle-backed tuple pricing
+- Query deposit state
 
 ## Installation
 
 ```bash
+bun add @zkp2p/sdk viem
+# or
 npm install @zkp2p/sdk viem
 # or
 yarn add @zkp2p/sdk viem
@@ -28,10 +36,8 @@ pnpm add @zkp2p/sdk viem
 
 ## Quick start
 
-### Initialize the client
-
 ```ts
-import { OfframpClient } from '@zkp2p/sdk';
+import { Zkp2pClient } from '@zkp2p/sdk';
 import { createWalletClient, custom } from 'viem';
 import { base } from 'viem/chains';
 
@@ -40,230 +46,261 @@ const walletClient = createWalletClient({
   transport: custom(window.ethereum),
 });
 
-const client = new OfframpClient({
+const client = new Zkp2pClient({
   walletClient,
   chainId: base.id,
-  apiKey: 'YOUR_API_KEY', // Optional for API operations
+  runtimeEnv: 'production', // 'production' | 'preproduction' | 'staging'
+  apiKey: 'YOUR_CURATOR_API_KEY', // optional if you pass payeeDetailsHashes directly
+  indexerApiKey: 'YOUR_INDEXER_API_KEY', // optional, for indexer proxy auth
 });
 ```
 
-## Core operations
+`OfframpClient` is still exported as a backward-compatible alias, but `Zkp2pClient` is the canonical name.
+
+## Core deposit operations
 
 ### Create a deposit
 
 ```ts
 import { Currency } from '@zkp2p/sdk';
 
-await client.createDeposit({
+const { hashedOnchainIds } = await client.registerPayeeDetails({
+  processorNames: ['wise'],
+  depositData: [{ email: 'maker@example.com' }],
+});
+
+const { hash } = await client.createDeposit({
   token: '0xUSDC_ADDRESS',
-  amount: 10000000000n, // 10,000 USDC (6 decimals)
-  intentAmountRange: { min: 100000n, max: 1000000000n },
-  processorNames: ['wise', 'revolut'],
-  depositData: [
-    { email: 'maker@example.com' }, // Wise payment details
-    { tag: '@maker' },              // Revolut payment details
-  ],
-  conversionRates: [
-    [{ currency: Currency.USD, conversionRate: '1020000000000000000' }], // 1.02 (18 decimals)
-    [{ currency: Currency.EUR, conversionRate: '950000000000000000' }],  // 0.95 (18 decimals)
-  ],
-  onSuccess: ({ hash }) => console.log('Deposit created:', hash),
+  amount: 10_000_000000n, // 10,000 USDC (6 decimals)
+  intentAmountRange: { min: 10_000000n, max: 1_000_000000n },
+  processorNames: ['wise'],
+  depositData: [{ email: 'maker@example.com' }],
+  conversionRates: [[
+    { currency: Currency.USD, conversionRate: '1020000000000000000' },
+    { currency: Currency.EUR, conversionRate: '950000000000000000' },
+  ]],
+  payeeDetailsHashes: hashedOnchainIds,
+  delegate: '0xDELEGATE_ADDRESS', // optional intent-ops delegate
+  intentGuardian: '0xGUARDIAN_ADDRESS', // optional
+  retainOnEmpty: true, // optional
 });
 ```
 
-### Manage deposit settings
+### Update deposit settings
 
 ```ts
 await client.setAcceptingIntents({ depositId: 1n, accepting: true });
 
-await client.setIntentRange({ depositId: 1n, min: 50000n, max: 5000000n });
+await client.setIntentRange({
+  depositId: 1n,
+  min: 25_000000n,
+  max: 500_000000n,
+});
 
 await client.setCurrencyMinRate({
   depositId: 1n,
-  paymentMethod: '0x...',
-  fiatCurrency: '0x...',
-  minConversionRate: 1020000n,
+  paymentMethod: '0xPAYMENT_METHOD_HASH',
+  fiatCurrency: '0xFIAT_CURRENCY_HASH',
+  minConversionRate: 1_020_000_000_000_000_000n, // 1.02 (18 decimals)
 });
 ```
 
-### Fund management
+### Manage funds
 
 ```ts
-await client.addFunds({ depositId: 1n, amount: 5000000n });
-await client.removeFunds({ depositId: 1n, amount: 1000000n });
+await client.addFunds({ depositId: 1n, amount: 500_000000n });
+await client.removeFunds({ depositId: 1n, amount: 100_000000n });
 await client.withdrawDeposit({ depositId: 1n });
 ```
 
-## Querying on-chain data (RPC-first)
+### Prepared transaction flow
+
+Every `PrepareableMethod` supports `.prepare()` if you want to separate build/send:
 
 ```ts
-const deposits = await client.getDeposits();
-const ownerDeposits = await client.getAccountDeposits('0xOwnerAddress');
-const deposit = await client.getDeposit(42n);
-const batch = await client.getDepositsById([1n, 2n, 3n]);
+const prepared = await client.setOracleRateConfig.prepare({
+  depositId: 1n,
+  paymentMethodHash: '0xPAYMENT_METHOD_HASH',
+  currencyHash: '0xCURRENCY_HASH',
+  config: {
+    adapter: '0xADAPTER',
+    adapterConfig: '0x...',
+    spreadBps: 50,
+    maxStaleness: 86_400,
+  },
+});
 
-const intents = await client.getIntents();
-const ownerIntents = await client.getAccountIntents('0xOwnerAddress');
-const intent = await client.getIntent('0xIntentHash...');
+// send prepared.to + prepared.data with your own transaction pipeline
 ```
 
-## Indexer queries
+## Rate modes
 
-```ts
-const deposits = await client.indexer.getDeposits(
-  { status: 'ACTIVE', minLiquidity: '1000000', depositor: '0xYourAddress' },
-  { limit: 50, orderBy: 'remainingDeposits', orderDirection: 'desc' }
-);
+Each payment-method/currency tuple can run one of these pricing strategies:
 
-const depositsWithRelations = await client.indexer.getDepositsWithRelations(
-  { status: 'ACTIVE' },
-  { limit: 50 },
-  { includeIntents: true, intentStatuses: ['SIGNALED'] }
-);
+1. Fixed Rate: depositor sets `minConversionRate` manually.
+2. Market Tracking (ARM): depositor sets oracle + spread config (`setOracleRateConfig`).
 
-const fulfillments = await client.indexer.getFulfilledIntentEvents(['0x...']);
-```
+Precision and units:
 
-## Payment methods
+- USDC amounts: 6 decimals
+- Rates and fees: 18-decimal bigint units
+- ARM spread: signed basis points (`50 = +0.50%`, `-50 = -0.50%`)
 
-Supported payment platforms and keys:
+## ARM (Automated Rate Management)
 
-| Platform | Key |
-|----------|-----|
-| Wise | `wise` |
-| Venmo | `venmo` |
-| Revolut | `revolut` |
-| CashApp | `cashapp` |
-| PayPal | `paypal` |
-| Zelle | `zelle` |
-| Monzo | `monzo` |
-| MercadoPago | `mercadopago` |
+Use ARM to track oracle prices with a configurable spread.
 
-```ts
-import { getPaymentMethodsCatalog, PLATFORM_METADATA, PAYMENT_PLATFORMS } from '@zkp2p/sdk';
-
-console.log(PAYMENT_PLATFORMS);
-
-const methods = getPaymentMethodsCatalog(8453, 'production');
-const wiseHash = methods['wise'].paymentMethodHash;
-
-const wiseInfo = PLATFORM_METADATA['wise'];
-console.log(wiseInfo.displayName);
-```
-
-## Currency utilities
+### Configure oracle pricing for a tuple
 
 ```ts
 import {
   Currency,
-  currencyInfo,
-  getCurrencyInfoFromHash,
   resolveFiatCurrencyBytes32,
+  getPaymentMethodsCatalog,
+  getSpreadOracleConfig,
 } from '@zkp2p/sdk';
 
-const usd = Currency.USD;
-const info = currencyInfo[Currency.USD];
-const usdBytes = resolveFiatCurrencyBytes32('USD');
-```
+const paymentMethods = getPaymentMethodsCatalog(client.chainId, client.runtimeEnv);
+const paymentMethodHash = paymentMethods.wise.paymentMethodHash;
+const currencyHash = resolveFiatCurrencyBytes32(Currency.EUR);
 
-## Contract helpers
+const oracle = getSpreadOracleConfig(Currency.EUR);
+if (!oracle) throw new Error('No oracle feed configured for EUR');
 
-```ts
-import { getContracts, getPaymentMethodsCatalog } from '@zkp2p/sdk';
-
-const { addresses, abis } = getContracts(8453, 'production');
-const catalog = getPaymentMethodsCatalog(8453, 'production');
-```
-
-## Supported networks
-
-| Network | Chain ID | Environment |
-|---------|----------|-------------|
-| Base Mainnet | 8453 | `production` |
-| Base Sepolia | 84532 | `staging` |
-
-## Token allowance management
-
-```ts
-import { getContracts } from '@zkp2p/sdk';
-
-const { addresses } = getContracts(8453, 'production');
-
-const result = await client.ensureAllowance({
-  token: '0xUSDC_ADDRESS',
-  amount: 10000000000n,
-  spender: addresses.escrow,
-  maxApprove: false,
+await client.setOracleRateConfig({
+  depositId: 1n,
+  paymentMethodHash,
+  currencyHash,
+  config: {
+    adapter: oracle.adapter,
+    adapterConfig: oracle.adapterConfig,
+    spreadBps: 75,
+    maxStaleness: oracle.maxStaleness,
+  },
 });
-
-if (result.hadAllowance) {
-  console.log('Already had sufficient allowance');
-} else {
-  console.log('Approval transaction:', result.hash);
-}
 ```
 
-## Error handling
+### Remove oracle pricing for a tuple
 
 ```ts
-import { ValidationError, NetworkError, ContractError } from '@zkp2p/sdk';
-
-try {
-  await client.createDeposit({ /* ... */ });
-} catch (error) {
-  if (error instanceof ValidationError) {
-    console.error('Invalid parameters:', error.message);
-  } else if (error instanceof NetworkError) {
-    console.error('Network issue:', error.message);
-  } else if (error instanceof ContractError) {
-    console.error('Contract error:', error.message);
-  }
-}
+await client.removeOracleRateConfig({
+  depositId: 1n,
+  paymentMethodHash,
+  currencyHash,
+});
 ```
 
-## Logging
+### Batch ARM updates
 
 ```ts
-import { setLogLevel } from '@zkp2p/sdk';
-
-setLogLevel('debug'); // 'debug' | 'info' | 'warn' | 'error' | 'none'
+await client.setOracleRateConfigBatch({
+  depositId: 1n,
+  paymentMethods: [paymentMethodHash],
+  currencies: [[currencyHash]],
+  configs: [[{
+    adapter: oracle.adapter,
+    adapterConfig: oracle.adapterConfig,
+    spreadBps: 25,
+    maxStaleness: 86_400,
+  }]],
+});
 ```
+
+### ARM at deposit creation (overrides)
+
+`createDeposit` supports on-chain override arrays when you need tuple-level control.
+If you use overrides, provide these together:
+
+- `paymentMethodsOverride`
+- `paymentMethodDataOverride`
+- `currenciesOverride`
+
+```ts
+import {
+  Currency,
+  resolveFiatCurrencyBytes32,
+  getSpreadOracleConfig,
+} from '@zkp2p/sdk';
+
+const eurOracle = getSpreadOracleConfig(Currency.EUR);
+if (!eurOracle) throw new Error('EUR oracle not configured');
+
+await client.createDeposit({
+  token: '0xUSDC_ADDRESS',
+  amount: 1_000_000000n,
+  intentAmountRange: { min: 10_000000n, max: 100_000000n },
+  processorNames: ['wise'],
+  depositData: [{ email: 'maker@example.com' }],
+  conversionRates: [[{ currency: Currency.EUR, conversionRate: '900000000000000000' }]],
+  paymentMethodsOverride: ['0xPAYMENT_METHOD_HASH'],
+  paymentMethodDataOverride: [{
+    intentGatingService: '0xGATING_SERVICE',
+    payeeDetails: '0xPAYEE_HASH',
+    data: '0x',
+  }],
+  currenciesOverride: [[{
+    code: resolveFiatCurrencyBytes32(Currency.EUR),
+    minConversionRate: 900_000_000_000_000_000n,
+    oracleRateConfig: {
+      adapter: eurOracle.adapter,
+      adapterConfig: eurOracle.adapterConfig,
+      spreadBps: 60,
+      maxStaleness: eurOracle.maxStaleness,
+    },
+  }]],
+});
+```
+
+Useful ARM constants/utilities exported by the SDK:
+
+- `CHAINLINK_ORACLE_ADAPTER`
+- `PYTH_ORACLE_ADAPTER`
+- `DEFAULT_ORACLE_MAX_STALENESS_SECONDS`
+- `CHAINLINK_ORACLE_FEEDS`
+- `PYTH_ORACLE_FEEDS`
+- `encodeSpreadOracleAdapterConfig(...)`
+- `getSpreadOracleConfig(...)`
+
+## Indexer queries for deposits
+
+```ts
+const deposits = await client.indexer.getDeposits(
+  { status: 'ACTIVE', depositor: '0xYOUR_ADDRESS' },
+  { limit: 25, orderBy: 'updatedAt', orderDirection: 'desc' },
+);
+
+const deposit = await client.indexer.getDepositById('8453_0xESCROW_ADDRESS_1');
+const firstTuple = deposit?.currencies?.[0];
+console.log(firstTuple?.rateSource);
+```
+
+`MethodCurrency.rateSource` indicates why a tuple's current rate is active:
+
+- `ORACLE`: market tracking rate active
+- `ESCROW_FLOOR`: floor rate is active
+- `ORACLE_HALTED`: oracle configured but stale/invalid; tuple halted
+- `NO_FLOOR`: no active floor/rate configured
 
 ## React hooks
 
 ```tsx
 import {
   useCreateDeposit,
-  useAddFunds,
-  useRemoveFunds,
-  useWithdrawDeposit,
   useSetAcceptingIntents,
   useSetIntentRange,
   useSetCurrencyMinRate,
+  useAddFunds,
+  useRemoveFunds,
+  useWithdrawDeposit,
 } from '@zkp2p/sdk/react';
-
-function DepositManager({ client }) {
-  const { createDeposit, isLoading, error } = useCreateDeposit({ client });
-
-  const handleCreate = async () => {
-    const result = await createDeposit({
-      token: '0xUSDC_ADDRESS',
-      amount: 10000000000n,
-      intentAmountRange: { min: 100000n, max: 1000000000n },
-      processorNames: ['wise'],
-      depositData: [{ email: 'maker@example.com' }],
-      conversionRates: [[{ currency: 'USD', conversionRate: '1020000000000000000' }]],
-    });
-    console.log('Created deposit:', result.hash);
-  };
-
-  return (
-    <div>
-      <button disabled={isLoading} onClick={handleCreate}>
-        {isLoading ? 'Creating...' : 'Create Deposit'}
-      </button>
-      {error && <p>Error: {error.message}</p>}
-    </div>
-  );
-}
 ```
+
+- `useCreateDeposit`: creates deposits
+- `useSetAcceptingIntents`: toggles intent acceptance
+- `useSetIntentRange`: updates per-order min/max
+- `useSetCurrencyMinRate`: updates fixed floor rate per tuple
+- `useAddFunds` / `useRemoveFunds` / `useWithdrawDeposit`: manages liquidity
+
+## Next pages
+
+- [Automated Rate Management](automated-rate-management.md)

--- a/guides-sidebars.js
+++ b/guides-sidebars.js
@@ -23,6 +23,7 @@ module.exports = {
       link: { type: 'doc', id: 'for-sellers/index' },
       items: [
         'for-sellers/provide-liquidity-sell-usdc',
+        'for-sellers/market-tracking-arm',
         'for-sellers/provide-liquidity-diff-chain',
         'for-sellers/update-usdc-rates',
         'for-sellers/calculating-apr',

--- a/guides/for-sellers/index.md
+++ b/guides/for-sellers/index.md
@@ -4,19 +4,18 @@ title: For Sellers
 
 # For Sellers
 
-### Why Sell on ZKP2P?
+### Why sell on ZKP2P?
 
-In ZKP2P, all transactions are fully peer-to-peer, meaning onrampers are buying crypto directly from offrampers.
+In ZKP2P, all transactions are peer-to-peer, so buyers purchase crypto directly from sellers.
 
-Sellers receive payments on **Revolut, Cash App, Venmo, Wise**, and **Mercado Pago**, and buyers receive **USDC automatically**. Unlike other P2P marketplaces, the ZKP2P protocol **automatically verifies proof of payment** from the buyer using cryptography.
+Sellers receive payments on **Revolut, Cash App, Venmo, Wise**, and **Mercado Pago**, while buyers receive **USDC automatically**. ZKP2P verifies payment proofs cryptographically, so sellers do not need to manually release in normal flows.
 
-You don’t need to be online to manually release crypto. Simply **deposit USDC** and passively wait for fiat to arrive in your payment account. Charge a spread to earn yield (often **>50% APR**) and rebalance your fiat back into crypto every few days.
+You can deposit USDC, earn spread yield, and rebalance on your own cadence.
 
-### Get Started
-
-Below are guides to get started as a seller of USDC on ZKP2P:
+### Get started
 
 - [How to Provide Liquidity and Sell USDC](provide-liquidity-sell-usdc.md)
+- [Market Tracking (Automated Rate Management)](market-tracking-arm.md)
 - [How to Provide Liquidity from another chain](provide-liquidity-diff-chain.md)
 - [How to Update USDC Conversion Rates](update-usdc-rates.md)
 - [Calculating APR](calculating-apr.md)

--- a/guides/for-sellers/market-tracking-arm.md
+++ b/guides/for-sellers/market-tracking-arm.md
@@ -1,0 +1,76 @@
+---
+id: market-tracking-arm
+title: Market Tracking (Automated Rates)
+---
+
+# Market Tracking (Automated Rates)
+
+Market Tracking uses Automated Rate Management (ARM) to follow live market pricing.
+Instead of updating each conversion rate manually, you set a spread and floor.
+
+## What this does
+
+With Market Tracking enabled for a payment/currency pair:
+
+- The protocol reads a live oracle market rate.
+- Your spread is applied to that market rate.
+- Your floor still protects you when needed.
+
+In simple terms: you keep a minimum acceptable rate while still tracking the market.
+
+## What you control
+
+- Spread percentage (your premium/discount vs market)
+- Floor rate (minimum acceptable rate)
+- Which payment and currency pairs use Market Tracking
+
+## Market Tracking vs Fixed Rate
+
+Use Market Tracking when:
+
+- FX moves frequently
+- You do not want to manually update rates every day
+- You want pricing tied to live market data
+
+Use Fixed Rate when:
+
+- You want exact static pricing
+- You prefer manual control per tuple
+
+## Oracle stale behavior
+
+If a market feed becomes stale, that tuple pauses and new orders for that tuple stop until pricing is healthy again.
+
+:::info
+A stale market feed does not move your funds. It only pauses matching for the affected tuple.
+:::
+
+## Enable Market Tracking on a new deposit
+
+1. Start deposit creation from the **Sell** flow.
+2. In the rate step, choose **Market Tracking** for the tuple.
+3. Set your **spread (%)**.
+4. Set your **floor**.
+5. Review and confirm the deposit transaction.
+
+For the full deposit flow, see [How to Provide Liquidity and Sell USDC](provide-liquidity-sell-usdc.md).
+
+## Enable Market Tracking on an existing deposit
+
+1. Go to the **Sell** tab.
+2. Open your deposit details.
+3. In **Conversion Rates**, click edit for a tuple.
+4. Switch rate strategy to **Market Tracking**.
+5. Set spread and floor.
+6. Confirm the update transaction.
+
+## Best practices
+
+- Start with a wider spread (for example 2-3%) and tighten as fills stabilize.
+- Keep a floor that reflects your minimum acceptable payout.
+- Monitor fill speed by currency; different currencies often need different spreads.
+
+## Next
+
+- [How to Update USDC Conversion Rates](update-usdc-rates.md)
+- [How to Provide Liquidity and Sell USDC](provide-liquidity-sell-usdc.md)

--- a/guides/for-sellers/provide-liquidity-sell-usdc.md
+++ b/guides/for-sellers/provide-liquidity-sell-usdc.md
@@ -5,7 +5,7 @@ title: How to Provide Liquidity and Sell USDC
 
 # How to Provide Liquidity and Sell USDC
 
-This guide will walk you through the process of providing liquidity on ZKP2P.
+This guide walks through creating a seller deposit on ZKP2P.
 
 ### Step 1: Navigate to ZKP2P
 
@@ -13,181 +13,177 @@ Visit [https://peer.xyz](https://peer.xyz) in your browser.
 
 ![Provide Step 1](/img/onramping/OnrampStep1.png)
 
-
 ### Step 2: Check Current Market Rates
 
-- Click on the **Liquidity** tab in the main navigation bar  
-- Review current spreads and rates for the currencies you're interested in  
-- Pay attention to available liquidity and limits for each option  
+- Click the **Liquidity** tab in the main navigation.
+- Review current spreads and rates for currencies you want to support.
+- Check available liquidity and order limits.
 
 ![Provide Step 2](/img/provide-liquidity/ProvideStep2.png)
 
-
 ### Step 3: Add Liquidity
 
-- Click the add liquidity button on the top right hand side of the Order Book
+- Click the add-liquidity button at the top-right of the order book.
 
 ![Provide Step 3](/img/provide-liquidity/ProvideStep2.png)
 
-
-You can also click the **Sell** button on the toolbar 
+You can also click **Sell** in the main toolbar.
 
 ![Provide Step 3](/img/provide-liquidity/ProvideStep3a.png)
 
-
 ### Step 4: Connect
 
-- The platform will prompt you to connect your wallet  
-- Select your preferred wallet (Rabby, MetaMask, etc.) or log in via email, Twitter, or Google  
-- Approve the connection request in your wallet
+- Connect your wallet (Rabby, MetaMask, etc.) or sign in with social login.
+- Approve the connection request.
 
 ### Step 5: Fund Account with USDC on Base
 
-- Ensure you have sufficient **USDC tokens on the Base Network** by checking in the top right hand corner. 
+- Confirm you have enough **USDC on Base** in the top-right wallet area.
 
 ![Provide Step 5](/img/provide-liquidity/ProvideStep5.png)
 
-**- If you dont have enough USDC, check out the guide to depositing from any chain here!**
+If you need to bridge first, use the cross-chain liquidity guide.
 
 ### Step 6: Create New Deposit
 
-- Click the **New Deposit** button
+- Click **New Deposit**.
 
 ![Provide Step 6](/img/provide-liquidity/ProvideStep3a.png)
 
-
 ### Step 7: Deposit USDC to Sell
 
-- Click **Max** to deposit your full USDC balance or type a custom amount  
+- Click **Max** or enter a custom amount.
 
 ![Provide Step 7](/img/provide-liquidity/ProvideStep7.png)
 
-
 ### Step 8: Add Telegram Username (Optional)
 
-- Enter your Telegram username so buyers can contact you if any issues arise  
+- Enter your Telegram username for buyer support.
 
 ![Provide Step 8](/img/provide-liquidity/ProvideStep7.png)
 
 ### Step 9: Select Primary Payment Platform
 
-Choose your preferred platform from the dropdown:
+Choose the platform you want to accept:
 
-- Venmo (USD Only)  
-- Cash App (USD Only)  
-- Zelle (USD Only)
-- Revolut (Multi Currency)  
-- Wise (Multi Currency)  
-- Mercado Pago (ARS Only)
-- PayPal (Multi Currency)
-- Monzo (GBP Only)
+- Venmo (USD only)
+- Cash App (USD only)
+- Zelle (USD only)
+- Revolut (multi-currency)
+- Wise (multi-currency)
+- Mercado Pago (ARS only)
+- PayPal (multi-currency)
+- Monzo (GBP only)
 
 ![Provide Step 9](/img/provide-liquidity/ProvideStep9a.png)
 
-
 ### Step 10: Enter Payee Details
 
-Enter your username/account details for the selected platform:
+Enter your account details for the selected platform.
 
-- Venmo Username  
-- Cash App Cashtag  
-- Revolut Revtag  
-- Wise Wisetag  
-- Mercado Pago CVU  
+- Venmo username
+- Cash App cashtag
+- Revolut revtag
+- Wise email/tag
+- Mercado Pago CVU
 
-> 🔍 **Double-check accuracy** — these details are how buyers send you money.
+Double-check these values before continuing.
 
 ![Provide Step 10](/img/provide-liquidity/ProvideStep9.png)
 
+### Step 11: Choose a Rate Mode and Set Rates
 
-### Step 11: Set Exchange Rates
+For each payment/currency pair, choose one of two modes:
 
-- Enter how much you want to sell your USDC for in each currency  
-- Adjust based on what you observed in Step 2
-- You can see your percentage spread in the middle column
-    - Green is above market rate, Grey is close to market rate, and Red is below market rate. 
+1. **Fixed Rate**: manually set your conversion rate.
+2. **Market Tracking**: track market pricing automatically and set a spread.
 
-💡 **Consider**:
-- Market demand  
-- Competitive rates  
-- Desired profit margin
+For **Fixed Rate**:
 
-View the guide on optimal currency conversion rates for more tips.
+- Enter the rate you want to offer for each currency.
+- Use the spread indicator to gauge competitiveness.
+  - Green: above market
+  - Gray: near market
+  - Red: below market
+
+For **Market Tracking**:
+
+- Select **Market Tracking**.
+- Set your spread percentage.
+- Optionally set a floor rate.
+
+:::info
+Market Tracking uses oracle-backed pricing to follow live FX rates. You set strategy (spread and floor), and rates update automatically.
+:::
 
 ![Provide Step 11](/img/provide-liquidity/ProvideStep11.png)
 
-
 ### Step 12: Add Secondary Payment Platform (Optional)
 
-- Click **Add Payment** in the top right hand corner, if you want to accept multiple payment methods  
-- Repeat Steps 9–11 for the new platform  
+- Click **Add Payment** in the top-right.
+- Repeat Steps 9-11 for each additional platform.
 
 ![Provide Step 12](/img/provide-liquidity/ProvideStep12.png)
 
-
 ### Step 13: Configure Order Limits (Optional)
 
-- Click **Order Limits** to expand options  
-- Set **minimum** and **maximum** order sizes (e.g. 5 USDC → max: your total deposit) 
+- Expand **Order Limits**.
+- Set minimum and maximum order size.
 
 ![Provide Step 13](/img/provide-liquidity/ProvideStep13.png)
 
-### Step 14: Review your details
+### Step 14: Review Your Details
 
-- Are my tags correct?
-- Are my spreads what I expected?
-- How what proceeds can I expect from providing liquidity? 
+Before submitting, check:
 
-If all details are correct you can continue with your transaction! 
+- Payment tags/details
+- Rate strategy and spreads
+- Expected proceeds
 
 ![Provide Step 14](/img/provide-liquidity/ProvideStep14.png)
 
+### Step 15: Approve and Deposit
 
-### Step 15: Approve & Deposit into Vault
-
-- Click **Approve**  
-- After approval, confirm the **deposit transaction**
-- Gas is sponsored if you sign in with Socials
-- Wait for confirmation (10–20 seconds)  
-
+- Click **Approve**.
+- Confirm the deposit transaction.
+- Gas may be sponsored for social-login accounts.
+- Wait for confirmation.
 
 ![Provide Step 15](/img/provide-liquidity/ProvideStep15.png)
 
-
 ### Step 16: Monitor Your Deposit
 
-- Go to the **Sell** tab  
-- You’ll see your active deposit showing:
-  - Total amount
-  - Remaining balance
-  - Accepted currencies/platforms
-  - Current status  
+Go to the **Sell** tab and open your deposit.
+
+You can track:
+
+- Total and remaining amount
+- Enabled platforms/currencies
+- Current status
+- Selected rate mode (Fixed Rate or Market Tracking)
 
 ![Provide Step 17](/img/provide-liquidity/ProvideStep17.png)
 ![Provide Step 17a](/img/provide-liquidity/ProvideStep17a.png)
 
+## Important tips
 
----
+### Setting rates
 
-## 💡 Important Tips
+- Lower spreads (0.5-1%) usually fill faster with lower margin.
+- Higher spreads (1-3%) usually fill slower with higher margin.
+- Market Tracking can reduce manual updates; tune spread over time.
 
-### Setting Optimal Rates
+### Security best practices
 
-- Check the **Spread** column in the Liquidity tab  
-- Lower spreads (0.5–1%) = faster fills, less profit  
-- Higher spreads (1–3%) = slower fills, more profit  
-
-### Security Best Practices
-
-- Start with a **small deposit**  
-- Never share your wallet seed phrase  
-- Always double-check transaction details  
-- Use separate payment accounts for ZKP2P for clean tracking  
+- Start with a small deposit.
+- Never share your wallet seed phrase.
+- Double-check transaction details.
+- Use separate payment accounts for cleaner reconciliation.
 
 ### Troubleshooting
 
-- Long pending? Check gas — you need ETH on Base  
-- Deposit not appearing? Refresh or reconnect wallet  
-- Still stuck? Join [Peer Telegram](https://t.me/+XDj9FNnW-xs5ODNl) for help  
+- Pending too long: confirm you have ETH on Base for gas (if gas is not sponsored).
+- Deposit not visible: refresh and reconnect wallet.
+- Need help: join [Peer Telegram](https://t.me/+XDj9FNnW-xs5ODNl).
 
-➡️ _Next: [How to Update USDC Conversion Rates](update-usdc-rates.md)_
+➡️ _Next: [Market Tracking (Automated Rates)](market-tracking-arm.md)_

--- a/guides/for-sellers/update-usdc-rates.md
+++ b/guides/for-sellers/update-usdc-rates.md
@@ -5,92 +5,89 @@ title: How to Update USDC Conversion Rates
 
 # How to Update USDC Conversion Rates
 
-After creating your deposit in ZKP2P, you may need to adjust your conversion rates to stay competitive or respond to market changes. This guide walks you through how to update your FX rates for existing deposits.
+After creating a deposit, you can manage tuple pricing in two modes:
 
-### Step 1: Navigate to Your Deposit Details
+- **Fixed Rate**: update the rate manually.
+- **Market Tracking**: set spread and floor while rates follow market data.
 
-- Go to [https://peer.xyz](https://peer.xyz)  
-- Click on the **Sell** tab in the main navigation bar  
-- Find your active deposit in the list and click to view details  
+### Step 1: Navigate to your deposit details
 
-![CR Step 1](/img/provide-liquidity/ProvideStep17.png)  
+- Go to [https://peer.xyz](https://peer.xyz)
+- Open the **Sell** tab
+- Select your deposit
 
-### Step 2: Locate the Conversion Rates Section
+![CR Step 1](/img/provide-liquidity/ProvideStep17.png)
 
-Scroll to the **Conversion Rates** section. You'll see:
+### Step 2: Locate the Conversion Rates section
 
-- Your configured **payment platforms** (e.g., Revolut)  
-- The **currencies** you accept (e.g., GBP, SGD, EUR)  
-- The **current conversion rate** for each currency \
+You will see:
 
-![CR Step 2](/img/provide-liquidity/ProvideStep17a.png)  
+- Payment platforms
+- Enabled currencies
+- Current rates and source
 
+![CR Step 2](/img/provide-liquidity/ProvideStep17a.png)
 
-### Step 3: Select the Rate to Update
+### Step 3: Select the tuple to update
 
-- Find the currency you'd like to update  
-- Click the **edit icon (pencil)** next to the current rate  
-- The "Update Conversion Rate" screen will appear  
+- Find the currency row
+- Click the edit icon
+- The update modal opens
 
-![CR Step 3](/img/conversion-rate/CRStep3.png)  
+![CR Step 3](/img/conversion-rate/CRStep3.png)
 
+### Step 4: Choose mode and update settings
 
-### Step 4: Enter Your New Rate
+The modal includes a rate strategy selector.
 
-In the modal, you'll see:
+For **Fixed Rate**:
 
-- Platform (e.g., Revolut)  
-- Currency (e.g., GBP)  
-- Current Rate (e.g., 0.8)  
-- **New Conversion Rate** input  
+- Enter a new direct conversion rate.
 
-Enter your new rate — e.g., changing **0.8 → 0.795** for GBP.
+For **Market Tracking**:
 
-![CR Step 4](/img/conversion-rate/CRStep4.png)  
+- Switch to **Market Tracking**.
+- Set your spread percentage.
+- Set/update your floor rate.
 
+![CR Step 4](/img/conversion-rate/CRStep4.png)
 
+:::info
+If an oracle feed becomes stale, that tuple halts instead of falling back automatically. This protects against outdated market pricing.
+:::
 
-### Step 5: Confirm Rate Update
+### Step 5: Confirm the update
 
-- Click the Update Rate button  
-- Your wallet will prompt you to sign the transaction  
-- This updates your rate on-chain in the smart contract  
+- Click **Save Rate Settings** (or equivalent update button)
+- Sign the wallet transaction
 
-### Step 6: Wait for Confirmation
+### Step 6: Wait for confirmation
 
-- Wait for the transaction to confirm on the Base Network
-- Once confirmed, your updated rate will show in the Conversion Rates section  
-- The new rate will apply to all future orders
+- Wait for Base confirmation
+- Refresh deposit details if needed
+- Verify updated settings in Conversion Rates
 
 ![CR Step 6](/img/conversion-rate/CRStep6.png)
 
+## Tips for better rate management
 
+### Stay competitive
 
-## Tips for Setting Optimal Rates
+- Check market and liquidity tab pricing regularly.
+- Compare per-currency opportunities.
 
-### Research Current Market Rates
+### Use the right mode
 
-- Check the Liquidity tab to see what other providers offer  
-- Look at external exchanges for reference FX rates  
+- Fixed Rate is best for strict manual control.
+- Market Tracking is best when you want less manual maintenance.
 
-### Consider Spread and Competitiveness
+### Tune spread over time
 
-- **Lower spreads** (0.5–1%) = faster sales, lower margin  
-- **Higher spreads** (1–3%) = higher margin, slower sales  
-- Balance depends on your strategy  
+- Slow fills: reduce spread.
+- Instant fills: consider widening spread slightly.
 
-### Monitor Performance
+### Watch by currency
 
-After updating rates:
+- Different currencies usually need different spread targets.
 
-- Monitor how quickly your orders are filled  
-- If they're slow to fill → lower your spread  
-- If they're filling instantly → raise your spread slightly  
-
-### Currency-Specific Strategies
-
-- Popular currencies like EUR may allow higher spreads  
-- Rare currencies might require more competitive rates  
-- Optimize for each currency independently  
-
-➡️ _Next: [Handling Manual Releases as a Seller](manual-releases.md)_
+➡️ _Next: [Market Tracking (Automated Rates)](market-tracking-arm.md)_


### PR DESCRIPTION
## Summary
- Refresh offramp integration developer docs with updated SDK patterns and clearer structure
- Add new Automated Rate Management (ARM) developer doc explaining oracle-backed pricing configuration
- Add Market Tracking (ARM) seller guide for setting spreads and floors instead of manual rate updates
- Update seller guides (provide liquidity, update rates) and sidebar navigation for new pages

## Test plan
- [ ] Run `yarn build` to verify no broken links or frontmatter issues
- [ ] Confirm new sidebar entries render correctly in guides and developer sections
- [ ] Review new ARM docs for accuracy against EscrowV2 oracle config