### PR TITLE
Update docs for Peer extension 0.4.9+ changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# ZKP2P Documentation Site
+
+Docusaurus 3.8.1 documentation site for Peer (ZKP2P) - a permissionless P2P protocol for exchanging fiat currencies for crypto.
+
+**Live site**: https://docs.peer.xyz
+
+## Architecture
+
+### Multi-Docs Plugin Structure
+
+Four separate documentation plugins with independent sidebars:
+
+| Plugin | Path | Route | Sidebar | Audience |
+|--------|------|-------|---------|----------|
+| `guides` | `/guides` | `/guides/*` | `guides-sidebars.js` | End users (buyers/sellers) |
+| `protocol` | `/protocol` | `/protocol/*` | `protocol-sidebars.js` | Technical readers |
+| `developer` | `/developer` | `/developer/*` | `developer-sidebars.js` | Integration developers |
+| `brand-kit` | `/brand-kit` | `/brand-kit/*` | `brand-kit-sidebars.js` | Partners/designers |
+
+### Custom Implementations
+
+- **Blog system**: Disabled in preset, custom implementation via `src/pages/blog.js`
+- **Dark mode only**: Light theme disabled (`colorMode.disableSwitch: true`)
+- **Raw markdown loader**: Webpack plugin for importing `.md` files as source strings
+
+## Directory Structure
+
+```
+docs/
+├── guides/                    # User guides (buyers/sellers)
+│   ├── for-buyers/
+│   ├── for-sellers/
+│   ├── introduction/
+│   └── privacy-safety/
+├── protocol/                  # Protocol technical docs
+│   ├── v2/                    # Legacy V2 contracts
+│   ├── v3/                    # Current V3 architecture
+│   └── peerauth-extension/    # Browser extension docs
+├── developer/                 # Integration documentation
+│   └── integrate-zkp2p/
+├── brand-kit/                 # Brand asset downloads
+├── blog/                      # Blog markdown (SEO/fallback)
+├── src/
+│   ├── brand/                 # Design system package (@zkp2p/brand)
+│   ├── css/                   # Global styles
+│   └── pages/                 # Custom React pages
+├── static/                    # Static assets
+├── docusaurus.config.js       # Main config
+└── *-sidebars.js              # Sidebar configs
+```
+
+## Development
+
+```bash
+yarn start     # Dev server at localhost:3000
+yarn build     # Production build to /build
+yarn serve     # Serve production build
+yarn clear     # Clear Docusaurus cache
+```
+
+## Documentation Conventions
+
+### Frontmatter
+
+All docs require YAML frontmatter:
+
+```yaml
+---
+id: unique-doc-id
+title: Document Title
+slug: /optional-custom-slug  # optional
+---
+```
+
+### Markdown Patterns
+
+- **Admonitions**: `:::info`, `:::note`, `:::warning`, `:::danger`
+- **Code blocks**: Use language hints (`ts`, `json`, `bash`, `solidity`)
+- **Tables**: HTML tables for complex layouts (deployments, addresses)
+- **Links**: Relative paths from section root
+
+### Writing Guidelines
+
+1. Start with "What this does" overview
+2. Include "Who is this for?" when relevant
+3. Provide copy-paste code examples
+4. Document all parameters in tables
+5. End with troubleshooting/common issues
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `docusaurus.config.js` | Site config, plugins, navbar, footer |
+| `*-sidebars.js` | Section-specific sidebar navigation |
+| `src/css/custom.css` | Global styles (~1650 lines) |
+| `src/brand/` | Design system package with AGENTS.md |
+
+## Related Repositories
+
+- `zkp2p-v2-contracts` - Smart contract source (deployments reference this)
+- `zkp2p-clients` - Web app monorepo
+- `@zkp2p/sdk` - SDK documented in developer section

--- a/developer/integrate-zkp2p/integrate-redirect-onramp.md
+++ b/developer/integrate-zkp2p/integrate-redirect-onramp.md
@@ -16,6 +16,14 @@ Integrate the ZKP2P onramp directly into your application by using the Peer exte
 - Supported assets (USDC, SOL, ETH, USDT, etc.)
 - Gasless transactions
 
+:::warning Peer Extension `0.4.9+` breaking change
+These docs target Peer extension manifest version `0.4.9` and later.
+
+- `callbackUrl` was removed from `peerExtensionSdk.onramp()`
+- `onProofComplete()` was removed from the extension SDK
+- `onIntentFulfilled()` is now the page callback to listen for completed onramp fulfillment
+:::
+
 <div style={{textAlign: 'center'}}>
   <img src="/img/developer/Integration1.png" alt="Onramp modal shown in the Peer side panel" width="400" />
   <p><em>Onramp modal shown in the Peer side panel</em></p>
@@ -28,8 +36,9 @@ Integration is simple:
 1. Install `@zkp2p/sdk` and import `peerExtensionSdk`.
 2. Check extension state. If it is not installed, call `peerExtensionSdk.openInstallPage()` to open the Chrome Web Store.
 3. Then request a connection with `peerExtensionSdk.requestConnection()`.
-4. Build your deeplink params object.
-5. Call `peerExtensionSdk.onramp()` to open the side panel.
+4. Register `peerExtensionSdk.onIntentFulfilled()` before opening the flow.
+5. Build your deeplink params object.
+6. Call `peerExtensionSdk.onramp()` to open the side panel.
 
 ```ts
 import { peerExtensionSdk } from '@zkp2p/sdk';
@@ -47,16 +56,21 @@ if (state === 'needs_connection') {
   }
 }
 
+const unsubscribe = peerExtensionSdk.onIntentFulfilled((result) => {
+  console.log('Peer order fulfilled:', result.intentHash, result.bridge.status);
+});
+
 peerExtensionSdk.onramp({
   referrer: 'Rampy Pay',
   referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  callbackUrl: 'https://demo.peer.xyz',
   inputCurrency: 'USD',
   inputAmount: '10',
   paymentPlatform: 'venmo',
   toToken: '8453:0x0000000000000000000000000000000000000000',
   recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
 });
+
+// Call unsubscribe() when your page no longer needs the listener.
 ```
 
 ### Peer Extension SDK API
@@ -87,7 +101,7 @@ import {
 - `checkConnectionStatus(): Promise<'connected' | 'disconnected' | 'pending'>` - Reads the current connection status.
 - `openSidebar(route: string): void` - Opens the Peer side panel to a specific route.
 - `onramp(params?: PeerExtensionOnrampParams): void` - Opens the onramp flow with the provided params.
-- `onProofComplete(callback: PeerProofCompleteCallback): () => void` - Subscribe to proof completion events. Returns an unsubscribe function.
+- `onIntentFulfilled(callback: PeerIntentFulfilledCallback): () => void` - Subscribe to onramp fulfillment events. Returns an unsubscribe function.
 - `getVersion(): Promise<string>` - Returns the extension version.
 - `openInstallPage(): void` - Opens the Chrome Web Store listing for the Peer extension.
 
@@ -98,21 +112,63 @@ import {
 - `openPeerExtensionInstallPage(options?: PeerExtensionSdkOptions): void` - Opens the Chrome Web Store listing.
 - `PEER_EXTENSION_CHROME_URL` - The Chrome Web Store URL for the Peer extension.
 
-### Deeplink Query Parameters
+### Onramp Parameters
 
 Pass these parameters as an object to `peerExtensionSdk.onramp()`. The SDK builds and validates the query string for you.
 
 | Parameter | Description | Type | Example |
 |-----------|-------------|------|---------| 
-| `referrer` | (Required) Your application name | String | `referrer=Rampy` |
+| `referrer` | (Recommended) Your application name shown in the extension | String | `referrer=Rampy` |
 | `referrerLogo` | (Recommended) Your application logo | String | `referrerLogo=https://<logo-link>` |
-| `callbackUrl` | (Recommended) URL to which users are redirected after successful onramp | String | `callbackUrl=https://<your-app>/<success>` |
-| `inputCurrency` | (Optional) Input currency user wants to swap. Defaults to users's national currency or USD. | String | `inputCurrency=USD` |
-| `inputAmount` | (Optional) Amount of input currency the user wants to swap | Number (upto 2 decimal places) | `inputAmount=12.34` |
-| `paymentPlatform` | (Optional) Payment platform user will onramp from | String | `paymentPlatform=venmo` |
-| `amountUsdc` | (Optional) Amount of output USDC the user wants to ramp to. Include 6 decimal places. | String | `amountUsdc=1000000` |
+| `inputCurrency` | (Optional) Input currency user wants to swap. Defaults to the user's local currency when available, otherwise USD. | String | `inputCurrency=USD` |
+| `inputAmount` | (Optional) Amount of input currency the user wants to swap | String or number (up to 6 decimal places) | `inputAmount=12.34` |
+| `paymentPlatform` | (Optional) Preferred payment platform for the initial quote. The user can still choose a different one in the extension. | String | `paymentPlatform=venmo` |
+| `amountUsdc` | (Optional) Exact USDC output amount in base units (`1000000` = `1` USDC). Requires `recipientAddress`. | String, number, or bigint | `amountUsdc=1000000` |
 | `toToken` | (Optional) Output token the user will onramp to | String (Has to be in the format explained below) | `toToken=8453:0x0000000000000000000000000000000000000000` |
 | `recipientAddress` | (Optional) Address to which the output tokens will be sent. | String | `recipientAddress=0xf39...66` |
+| `intentHash` | (Optional) Existing intent hash to reopen directly in the send-payment step. Must be a `0x`-prefixed 32-byte hex string. | String | `intentHash=0xabc...123` |
+
+### Completion Callback
+
+Register `peerExtensionSdk.onIntentFulfilled()` before calling `peerExtensionSdk.onramp()`.
+
+```ts
+const unsubscribe = peerExtensionSdk.onIntentFulfilled((result) => {
+  if (result.bridge.status === 'not_required') {
+    console.log('Funds delivered to destination wallet');
+    return;
+  }
+
+  console.log('Fulfill complete, bridge pending:', result.bridge.trackingUrl);
+});
+```
+
+The callback payload looks like this:
+
+```ts
+type PeerIntentFulfilledResult = {
+  intentHash: `0x${string}`;
+  status: 'fulfilled';
+  fulfillTxHash: `0x${string}`;
+  recipientAddress: string | null;
+  destinationToken: string | null;
+  bridge: {
+    required: boolean;
+    status: 'not_required' | 'pending';
+    trackingUrl?: string | null;
+    txHashes?: Array<{ txHash: `0x${string}`; chainId: number }>;
+    outputAmount?: string | null;
+    expectedOutputAmount?: string | null;
+  };
+};
+```
+
+Current callback semantics in extension `0.4.9`:
+
+- Non-bridge orders emit once with `bridge.status = 'not_required'`
+- Bridge orders emit once after fulfill succeeds with `bridge.status = 'pending'`
+- Bridge completion is not emitted as a second callback today; use `bridge.trackingUrl` or `bridge.txHashes` to continue tracking
+- The callback is delivered only to the tab that originally called `onramp()`
 
 ### To Token
 
@@ -156,7 +212,6 @@ chainId:tokenAddress
 peerExtensionSdk.onramp({
   referrer: 'Rampy Pay',
   referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  callbackUrl: 'https://demo.peer.xyz',
   toToken: '8453:0x0000000000000000000000000000000000000000',
   recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
 });
@@ -168,7 +223,6 @@ peerExtensionSdk.onramp({
 peerExtensionSdk.onramp({
   referrer: 'Rampy Pay',
   referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  callbackUrl: 'https://demo.peer.xyz',
   inputCurrency: 'USD',
   inputAmount: '10',
   toToken: '792703809:11111111111111111111111111111111',
@@ -186,10 +240,9 @@ Payment platform is not enforced. After opening the onramp in the side panel, th
 peerExtensionSdk.onramp({
   referrer: 'Rampy Pay',
   referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  callbackUrl: 'https://demo.peer.xyz',
   inputCurrency: 'EUR',
   inputAmount: '10',
-  paymentPlatform: 'Revolut',
+  paymentPlatform: 'revolut',
   toToken: '1:0x0000000000000000000000000000000000000000',
   recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
 });
@@ -209,11 +262,19 @@ Onramp exactly 1 USDC on Base to a recipient address. Users can choose their pre
 peerExtensionSdk.onramp({
   referrer: 'Rampy Pay',
   referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  callbackUrl: 'https://demo.peer.xyz',
   amountUsdc: '1000000',
   recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
 });
 ```
+
+### Migrating From Pre-`0.4.9`
+
+If your integration was built against the older extension contract:
+
+- Remove `callbackUrl` from every `peerExtensionSdk.onramp({...})` call
+- Replace `onProofComplete(...)` with `onIntentFulfilled(...)`
+- Register the callback before calling `onramp()`
+- If you were waiting for a redirect back to your page, keep the user on-page and update state from `onIntentFulfilled(...)` instead
 
 <div style={{textAlign: 'center'}}>
   <img src="/img/developer/Integration2.png" alt="Request instructions shown in the Peer side panel" width="400" />

--- a/static/onramp-llm.md
+++ b/static/onramp-llm.md
@@ -1,5 +1,7 @@
 Add an onramp button to this site's payment flow using `@zkp2p/sdk`. When a user clicks it:
 
+This prompt targets Peer extension manifest version `0.4.9+`. Do not use `callbackUrl` or `onProofComplete()`. Use `onIntentFulfilled()` instead.
+
 ## 1. Initialize the SDK
 
 Use a scoped instance — **not** the default singleton:
@@ -21,7 +23,25 @@ const state = await peerSdk.getState();
 - **`needs_connection`** — Call `peerSdk.requestConnection()`. If the user declines, show a message explaining the extension must be connected.
 - **`ready`** — Proceed to open the onramp.
 
-## 3. Open the onramp side panel
+## 3. Register the fulfillment callback before opening the flow
+
+```ts
+const unsubscribe = peerSdk.onIntentFulfilled((result) => {
+  if (result.bridge.status === 'not_required') {
+    console.log('Peer onramp complete:', result.intentHash);
+    return;
+  }
+
+  console.log('Peer fulfill complete, bridge pending:', result.bridge.trackingUrl);
+});
+```
+
+- Register the listener before calling `peerSdk.onramp(...)`.
+- Non-bridge flows emit once with `bridge.status = 'not_required'`.
+- Bridge flows emit once with `bridge.status = 'pending'`.
+- There is no second bridge-complete callback today. Use `trackingUrl` or `txHashes` to keep tracking.
+
+## 4. Open the onramp side panel
 
 ```ts
 peerSdk.onramp({
@@ -29,7 +49,8 @@ peerSdk.onramp({
   recipientAddress: '<connectedWalletAddr>',  // Omit if no wallet connected — button should work either way
   referrer: '<this-site-name>',               // Your application name
   referrerLogo: '<https://your-site/logo>',   // Must be http/https URL, not a data URI
-  callbackUrl: '<https://your-site/callback>',// URL to redirect back to after onramp
+  inputCurrency: 'USD',                       // Optional fiat currency
+  inputAmount: '25',                          // Optional fiat amount, up to 6 decimals
 });
 ```
 
@@ -37,15 +58,15 @@ peerSdk.onramp({
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `referrer` | Yes | Your application name |
+| `referrer` | Recommended | Your application name |
 | `referrerLogo` | Recommended | URL to your logo (must be `http`/`https`, not a data URI) |
-| `callbackUrl` | Recommended | URL users return to after completing the onramp |
 | `toToken` | Optional | Destination token in `chainId:tokenAddress` format |
 | `recipientAddress` | Optional | User's connected wallet address. Omit if no wallet is connected |
 | `inputCurrency` | Optional | Fiat currency code (e.g. `USD`, `EUR`). Defaults to user's locale |
-| `inputAmount` | Optional | Fiat amount to convert (up to 2 decimal places) |
-| `paymentPlatform` | Optional | Preferred payment method (e.g. `venmo`, `Revolut`) — not enforced |
-| `amountUsdc` | Optional | Exact USDC output amount with 6 decimals (e.g. `1000000` = 1 USDC). Overrides `toToken` and `inputAmount`. Requires `recipientAddress` |
+| `inputAmount` | Optional | Fiat amount to convert (up to 6 decimal places) |
+| `paymentPlatform` | Optional | Preferred payment method (e.g. `venmo`, `revolut`) — not enforced |
+| `amountUsdc` | Optional | Exact USDC output amount in base units (e.g. `1000000` = 1 USDC). Overrides `toToken` and `inputAmount`. Requires `recipientAddress` |
+| `intentHash` | Optional | Existing `0x`-prefixed 32-byte intent hash to reopen directly in the send-payment step |
 
 ### Supported chains for `toToken`
 
@@ -65,17 +86,17 @@ peerSdk.onramp({
 
 For EVM chains, use the zero address (`0x0000…0000`) for native currency. For non-EVM chains (e.g. Solana), use the native token's base-58 address.
 
-## 4. Button placement rules
+## 5. Button placement rules
 
 - Place the onramp button **next to any action that requires a token balance** (swap, stake, mint, bridge, etc.).
 - If the user's balance is too low (or no wallet is connected), **highlight the onramp button over the action button** — make the onramp the primary CTA and the action button secondary/disabled.
 - Add the onramp button to any **insufficient balance error states** (e.g. "Not enough ETH" banners, failed transaction modals).
 
-## 5. Full integration example
+## 6. Full integration example
 
 ```tsx
 import { createPeerExtensionSdk } from '@zkp2p/sdk';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const peerSdk = createPeerExtensionSdk({ window });
 
@@ -84,15 +105,26 @@ function OnrampButton({
   recipientAddress,
   siteName,
   siteLogo,
-  callbackUrl,
 }: {
   toToken: string;
   recipientAddress?: string;
   siteName: string;
   siteLogo: string;
-  callbackUrl: string;
 }) {
   const [showInstallModal, setShowInstallModal] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = peerSdk.onIntentFulfilled((result) => {
+      if (result.bridge.status === 'pending') {
+        console.log('Bridge pending:', result.bridge.trackingUrl);
+        return;
+      }
+
+      console.log('Peer onramp complete:', result.intentHash);
+    });
+
+    return unsubscribe;
+  }, []);
 
   const handleOnramp = async () => {
     const state = await peerSdk.getState();
@@ -112,7 +144,6 @@ function OnrampButton({
       ...(recipientAddress && { recipientAddress }),
       referrer: siteName,
       referrerLogo: siteLogo,
-      callbackUrl,
     });
   };
 
@@ -141,7 +172,9 @@ function OnrampButton({
 ## Key rules
 
 - Use `createPeerExtensionSdk({ window })` — **not** the default `peerExtensionSdk` singleton.
+- Register `onIntentFulfilled()` before calling `onramp()`.
 - Never silently redirect to the Chrome Web Store. Always show a modal first.
 - The button must work with **or without** a connected wallet — just omit `recipientAddress` if none.
 - `referrerLogo` must be an `http`/`https` URL, never a `data:` URI.
+- Do not pass `callbackUrl`; it was removed in Peer extension `0.4.9`.
 - Keep the integration minimal. No extra wrappers or abstractions.


### PR DESCRIPTION
## Summary
- document the breaking changes in the redirect-onramp guide (callback removal, onIntentFulfilled usage, renamed parameters)
- add intent fulfillment guidance, updated API table, and migration notes for manifest 0.4.9
- align the onramp-llm static doc with the new callback flow and parameter expectations

## Testing
- Not run (not requested)