### PR TITLE
Add SDK reference docs to developer section

### DIFF
--- a/developer-sidebars.js
+++ b/developer-sidebars.js
@@ -8,5 +8,14 @@ module.exports = {
     { type: 'doc', id: 'offramp-integration', label: 'Offramp Integration' },
     { type: 'doc', id: 'post-intent-hooks', label: 'Post‑Intent Hooks' },
     { type: 'doc', id: 'build-payment-integration', label: 'Build a Payment Integration' },
+    {
+      type: 'category',
+      label: 'SDK Reference',
+      link: { type: 'doc', id: 'sdk/sdk-overview' },
+      items: [
+        { type: 'doc', id: 'sdk/sdk-client-reference', label: 'Client Reference' },
+        { type: 'doc', id: 'sdk/sdk-react-hooks', label: 'React Hooks' },
+      ],
+    },
   ],
 };

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -10,7 +10,7 @@ slug: /sdk/client-reference
 
 This page documents the published `Zkp2pClient` API surface for `@zkp2p/sdk`. Use it as the reference layer for custom integrations after you have read the higher-level walkthroughs:
 
-- [Offramp Integration](/developer/developer/offramp)
+- [Offramp Integration](/developer/offramp-integration)
 - [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp)
 
 ## Constructor
@@ -332,7 +332,7 @@ For common read flows, start with the RPC-first methods:
 - `getDeployedAddresses()`
 - `getUsdcAddress()`
 
-For copy-paste examples around deposits and intents, see [Offramp Integration](/developer/developer/offramp).
+For copy-paste examples around deposits and intents, see [Offramp Integration](/developer/offramp-integration).
 
 ## Indexer
 

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -1,0 +1,462 @@
+---
+id: sdk-client-reference
+title: Client Reference
+slug: /sdk/client-reference
+---
+
+# Client Reference
+
+## What this does
+
+This page documents the published `Zkp2pClient` API surface for `@zkp2p/sdk`. Use it as the reference layer for custom integrations after you have read the higher-level walkthroughs:
+
+- [Offramp Integration](/developer/developer/offramp)
+- [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp)
+
+## Constructor
+
+Create a client with `new Zkp2pClient(opts)`.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `walletClient` | Yes | viem `WalletClient` with an attached account for signing |
+| `chainId` | Yes | Chain ID used for contract and API routing |
+| `rpcUrl` | No | Optional RPC override; otherwise the SDK uses the wallet client's chain transport |
+| `runtimeEnv` | No | Runtime environment: `production`, `preproduction`, or `staging`. Defaults to `production` |
+| `preferV2ByDefault` | No | Controls whether V2 contracts are preferred when both legacy and V2 are deployed |
+| `indexerUrl` | No | Override for the indexer GraphQL endpoint |
+| `baseApiUrl` | No | Override for ZKP2P service APIs |
+| `apiKey` | No | Curator API key used by authenticated endpoints such as `registerPayeeDetails()` and auto-signing for `signalIntent()` |
+| `authorizationToken` | No | Optional bearer token for hybrid authentication |
+| `getAuthorizationToken` | No | Async token provider for long-lived clients |
+| `indexerApiKey` | No | Optional `x-api-key` header for indexer proxy authentication |
+| `timeouts.api` | No | API timeout in milliseconds |
+
+```ts
+import { Zkp2pClient } from '@zkp2p/sdk';
+
+const client = new Zkp2pClient({
+  walletClient,
+  chainId: 8453,
+  runtimeEnv: 'production',
+  apiKey: 'YOUR_API_KEY',
+  indexerApiKey: 'YOUR_INDEXER_API_KEY',
+});
+```
+
+:::warning API-backed methods
+`registerPayeeDetails()` requires curator API access. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
+:::
+
+## Prepared transactions
+
+Most write methods are "prepareable":
+
+- Calling the method directly sends the transaction and returns a hash
+- Calling `.prepare()` on the same method returns a `PreparedTransaction` with `{ to, data, value, chainId }`
+
+```ts
+const prepared = await client.signalIntent.prepare({
+  depositId: 42n,
+  amount: 100_000000n,
+  toAddress: '0xYourRecipientAddress',
+  processorName: 'wise',
+  payeeDetails: '0xPayeeHash',
+  fiatCurrencyCode: 'USD',
+  conversionRate: 1_020000000000000000n,
+});
+
+await relayer.submit({
+  to: prepared.to,
+  data: prepared.data,
+  value: prepared.value,
+});
+```
+
+`createDeposit()` is the main exception because it may also post curator data. Use `prepareCreateDeposit()` when you need calldata without sending:
+
+```ts
+const { depositDetails, prepared } = await client.prepareCreateDeposit({
+  token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  amount: 1_000_000000n,
+  intentAmountRange: { min: 10_000000n, max: 500_000000n },
+  processorNames: ['wise'],
+  depositData: [{ email: 'maker@example.com' }],
+  conversionRates: [[
+    { currency: 'USD', conversionRate: '1020000000000000000' },
+  ]],
+});
+```
+
+## Payee registration
+
+Use `registerPayeeDetails()` when you want to register payment details first and reuse the returned hashes in a later `createDeposit()` call.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `processorNames` | `string[]` | Payment platforms such as `wise`, `revolut`, or `venmo` |
+| `depositData` | `Array<Record<string, string>>` | Processor-specific payment details in the same order as `processorNames` |
+
+```ts
+const { hashedOnchainIds } = await client.registerPayeeDetails({
+  processorNames: ['wise', 'revolut'],
+  depositData: [
+    { email: 'maker@example.com' },
+    { tag: '@maker' },
+  ],
+});
+
+await client.createDeposit({
+  token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  amount: 1_000_000000n,
+  intentAmountRange: { min: 10_000000n, max: 500_000000n },
+  processorNames: ['wise', 'revolut'],
+  depositData: [
+    { email: 'maker@example.com' },
+    { tag: '@maker' },
+  ],
+  conversionRates: [
+    [{ currency: 'USD', conversionRate: '1020000000000000000' }],
+    [{ currency: 'EUR', conversionRate: '950000000000000000' }],
+  ],
+  payeeDetailsHashes: hashedOnchainIds,
+});
+```
+
+## Intent operations
+
+### `signalIntent()` / `signalIntent.prepare()`
+
+Signals a taker-side intent and reserves liquidity from a deposit.
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `depositId` | Yes | Deposit ID to use |
+| `amount` | Yes | Token amount in base units |
+| `toAddress` | Yes | Recipient address for the on-chain asset |
+| `processorName` | Yes | Payment platform name |
+| `payeeDetails` | Yes | Hashed payee details for the deposit/payment method |
+| `fiatCurrencyCode` | Yes | Fiat currency such as `USD` or `EUR` |
+| `conversionRate` | Yes | Agreed conversion rate with 18 decimals |
+| `referralFees` | No | Multi-recipient referral fee list |
+| `referrer` / `referrerFee` | No | Deprecated legacy single-referrer fields |
+| `referrerFeeConfig` | No | Redirect/onramp-friendly referrer fee configuration |
+| `postIntentHook` | No | Post-intent hook contract address |
+| `preIntentHookData` | No | Data for a pre-intent hook |
+| `data` | No | Arbitrary bytes passed into hook-enabled flows |
+| `escrowAddress` | No | Escrow override when you want explicit routing |
+| `orchestratorAddress` | No | Orchestrator override |
+| `gatingServiceSignature` | No | Pre-obtained signature if you do not want SDK auto-fetching |
+| `signatureExpiration` | No | Signature expiration timestamp |
+| `txOverrides` | No | viem transaction overrides plus optional referrer code(s) |
+
+### `cancelIntent()` / `cancelIntent.prepare()`
+
+Cancels a signaled intent before fulfillment.
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `intentHash` | Yes | `0x`-prefixed 32-byte intent hash |
+| `orchestratorAddress` | No | Explicit orchestrator override |
+| `txOverrides` | No | viem transaction overrides |
+
+### `fulfillIntent()` / `fulfillIntent.prepare()`
+
+Fulfills a signaled intent with a payment proof. The SDK handles attestation encoding for you.
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `intentHash` | Yes | `0x`-prefixed 32-byte intent hash |
+| `proof` | Yes | Reclaim proof object or JSON string |
+| `timestampBufferMs` | No | Allowed timestamp variance in milliseconds |
+| `attestationServiceUrl` | No | Override for the attestation service |
+| `orchestratorAddress` | No | Explicit orchestrator override |
+| `postIntentHookData` | No | Hook payload passed to the orchestrator |
+| `txOverrides` | No | viem transaction overrides |
+| `callbacks` | No | UI lifecycle callbacks such as `onAttestationStart`, `onTxSent`, and `onTxMined` |
+| `precomputedAttestation` | No | Pre-encoded attestation data for advanced flows |
+
+### `releaseFundsToPayer()` / `releaseFundsToPayer.prepare()`
+
+Manual release path for returning reserved funds to the deposit owner when an intent should not be fulfilled.
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `intentHash` | Yes | `0x`-prefixed 32-byte intent hash |
+| `orchestratorAddress` | No | Explicit orchestrator override |
+| `txOverrides` | No | viem transaction overrides |
+
+## Vault and rate-manager operations
+
+At the client layer, vaults are exposed as rate managers. These flows are most relevant when you are delegating deposits or managing shared pricing.
+
+:::note
+`staging` defaults to V2 routing. Several vault, delegation, and oracle-backed pricing features are V2-only, even though the SDK still supports legacy fallback for broader deposit and intent flows.
+:::
+
+### Create a vault
+
+Use `createRateManager()` to create a new vault.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `config.manager` | Yes | Manager address |
+| `config.feeRecipient` | Yes | Address that receives manager fees |
+| `config.maxFee` | Yes | Maximum allowed fee |
+| `config.fee` | Yes | Current fee |
+| `config.depositHook` | No | Optional deposit hook contract |
+| `config.minLiquidity` | No | Minimum USDC liquidity required for delegation |
+| `config.name` | Yes | Human-readable name |
+| `config.uri` | Yes | Metadata URI |
+| `txOverrides` | No | viem transaction overrides |
+
+### Delegation methods
+
+Use one of the delegation paths below depending on how the deposit is routed.
+
+| Method | Use it when | Key parameters |
+| --- | --- | --- |
+| `setDepositRateManager()` | Delegating through the controller/registry path | `escrow`, `depositId`, `registry`, `rateManagerId` |
+| `clearDepositRateManager()` | Clearing controller-based delegation | `escrow`, `depositId` |
+| `setRateManager()` | Writing directly to EscrowV2 | `depositId`, `rateManagerAddress`, `rateManagerId`, `escrowAddress?` |
+| `clearRateManager()` | Clearing direct EscrowV2 delegation | `depositId`, `escrowAddress?` |
+
+### Vault configuration
+
+| Method | Description | Key parameters |
+| --- | --- | --- |
+| `setVaultFee()` | Update vault manager fee | `rateManagerId`, `newFee` |
+| `setVaultMinRate()` | Set floor rate for one payment method/currency pair | `rateManagerId`, `paymentMethodHash`, `currencyHash`, `rate` |
+| `setVaultMinRatesBatch()` | Batch version of `setVaultMinRate()` | `rateManagerId`, `paymentMethods`, `currencies`, `rates` |
+| `setVaultConfig()` | Update manager, fee recipient, hook, name, or URI | `rateManagerId`, `newManager`, `newFeeRecipient`, `newHook?`, `newName`, `newUri` |
+
+### Payment method management
+
+| Method | Description | Key parameters |
+| --- | --- | --- |
+| `addPaymentMethods()` | Add new payment platforms to an existing deposit | `depositId`, `paymentMethods`, `paymentMethodData`, `currencies` |
+| `setPaymentMethodActive()` | Activate or deactivate a payment method | `depositId`, `paymentMethod`, `isActive` |
+| `removePaymentMethod()` | Convenience alias for deactivating a payment method | `depositId`, `paymentMethod` |
+
+### Currency management
+
+| Method | Description | Key parameters |
+| --- | --- | --- |
+| `addCurrencies()` | Add currencies to an existing payment method | `depositId`, `paymentMethod`, `currencies` |
+| `deactivateCurrency()` | Disable a currency for a payment method | `depositId`, `paymentMethod`, `currencyCode` |
+| `removeCurrency()` | Alias for `deactivateCurrency()` | `depositId`, `paymentMethod`, `currencyCode` |
+
+### Rate-manager reads
+
+| Method | Returns | Notes |
+| --- | --- | --- |
+| `getDepositRateManager(escrow, depositId)` | `{ registry, rateManagerId }` | Reads current delegation state |
+| `getManagerFee(escrow, depositId)` | `bigint` | Reads the effective manager fee |
+| `getEffectiveRate({ escrow, depositId, paymentMethod, fiatCurrency })` | `bigint` | Reads effective EscrowV2 rate after manager logic |
+
+For EscrowV2 pricing flows, the client also exposes `setOracleRateConfig()`, `removeOracleRateConfig()`, `setOracleRateConfigBatch()`, `updateCurrencyConfigBatch()`, and `deactivateCurrenciesBatch()`.
+
+## Quote API
+
+Use `getQuote(req, opts?)` to fetch available liquidity for a taker flow.
+
+| Request field | Required | Description |
+| --- | --- | --- |
+| `paymentPlatforms` | Yes | Platforms to search, such as `['wise', 'revolut']` |
+| `fiatCurrency` | Yes | Fiat currency code |
+| `user` | Yes | Taker address |
+| `recipient` | Yes | Asset recipient address |
+| `destinationChainId` | Yes | Destination chain ID |
+| `destinationToken` | Yes | Destination token address |
+| `amount` | Yes | Amount as a string |
+| `referrer` | No | Referrer code for quote attribution |
+| `referrerFeeConfig` | No | Referrer fee recipient and BPS |
+| `useMultihop` | No | Enable multihop routing |
+| `quotesToReturn` | No | Limit quote count |
+| `isExactFiat` | No | Treat `amount` as fiat instead of token amount |
+| `escrowAddresses` | No | Limit search to specific escrows |
+| `includeNearbyQuotes` | No | Include nearby suggestions when no exact quote is available |
+| `nearbySearchRange` | No | Max percent deviation for nearby quote search |
+| `nearbyQuotesCount` | No | Number of nearby suggestions above and below |
+
+The response includes:
+
+- `responseObject.quotes`: matched quotes
+- `responseObject.nearbySuggestions`: optional nearby matches when `includeNearbyQuotes` is enabled and no exact quote is available
+- `signalIntentAmount`: gross amount you should pass into `signalIntent()` when a referrer fee is applied
+- `referrerFeeAmount`: computed fee output for the supplied `referrerFeeConfig`
+
+```ts
+const quote = await client.getQuote({
+  paymentPlatforms: ['wise'],
+  fiatCurrency: 'USD',
+  user: '0xYourAddress',
+  recipient: '0xRecipientAddress',
+  destinationChainId: 8453,
+  destinationToken: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  amount: '100',
+  isExactFiat: true,
+  includeNearbyQuotes: true,
+});
+```
+
+## Taker tiers
+
+Use `getTakerTier(req, opts?)` to fetch tiering, cooldown, and platform-limit data for a taker address.
+
+| Request field | Required | Description |
+| --- | --- | --- |
+| `owner` | Yes | Taker address |
+| `chainId` | Yes | Chain ID for tier evaluation |
+
+The response object includes:
+
+- `tier`: one of `PEASANT`, `PEER`, `PLUS`, `PRO`, `PLATINUM`, or `PEER_PRESIDENT`
+- `perIntentCapBaseUnits` and `perIntentCapDisplay`
+- cooldown metadata such as `cooldownHours`, `cooldownActive`, and `nextIntentAvailableAt`
+- `platformLimits`, including risk level and minimum required tier per payment platform
+
+## Querying on-chain data
+
+For common read flows, start with the RPC-first methods:
+
+- `getDeposits()`
+- `getAccountDeposits(owner)`
+- `getDeposit(depositId)`
+- `getDepositsById(ids)`
+- `getIntents()`
+- `getAccountIntents(owner)`
+- `getIntent(intentHash)`
+- `resolvePayeeHash(depositId, paymentMethodHash)`
+- `getFulfillIntentInputs(intentHash)`
+- `getDeployedAddresses()`
+- `getUsdcAddress()`
+
+For copy-paste examples around deposits and intents, see [Offramp Integration](/developer/developer/offramp).
+
+## Indexer
+
+Use `client.indexer` when you need historical data, richer filtering, or pagination across all deposits and intents.
+
+Common methods on `client.indexer`:
+
+- `getDeposits(filter?, pagination?)`
+- `getDepositsWithRelations(filter?, pagination?, options?)`
+- `getDepositById(id, options?)`
+- `getOwnerIntents(owner, statuses?)`
+- `getIntentByHash(intentHash)`
+- `getExpiredIntents({ now, depositIds, limit? })`
+- `getFulfilledIntentEvents(intentHashes)`
+- `getIntentFulfillmentAmounts(intentHash)`
+- `getFulfillmentAndPayment(intentHash)`
+- `getDepositsByPayeeHash(payeeHash, options?)`
+
+For rate-manager analytics, the package also exports `IndexerRateManagerService`, which you can construct from `client.indexer.client`.
+
+```ts
+import { IndexerRateManagerService } from '@zkp2p/sdk';
+
+const rateManagers = new IndexerRateManagerService(client.indexer.client);
+const list = await rateManagers.fetchRateManagers({ limit: 20 });
+```
+
+The package also exports the standalone helper `fetchFulfillmentAndPayment(client.indexer.client, intentHash)`.
+
+## Referrer fees
+
+Use these helpers when you want to validate or normalize referrer fee settings before calling `getQuote()` or `signalIntent()`.
+
+| Helper | Purpose |
+| --- | --- |
+| `assertValidReferrerFeeConfig(config, context)` | Throws if the config is invalid for `getQuote` or `signalIntent` |
+| `isValidReferrerFeeBps(value)` | Checks whether a BPS value is allowed |
+| `parseReferrerFeeConfig(recipient, feeBpsValue)` | Builds a `ReferrerFeeConfig` from loosely typed input |
+| `referrerFeeConfigToPreciseUnits(config)` | Converts the fee config into precise units for on-chain use |
+
+## Attribution
+
+The SDK includes ERC-8021 helpers for Base builder attribution.
+
+| Helper | Purpose |
+| --- | --- |
+| `getAttributionDataSuffix(referrer?)` | Builds the attribution suffix |
+| `appendAttributionToCalldata(calldata, referrer?)` | Appends attribution to existing calldata |
+| `encodeWithAttribution(request, referrer?)` | Encodes calldata and appends attribution in one step |
+| `sendTransactionWithAttribution(walletClient, request, referrer?, overrides?)` | Sends a transaction with appended attribution |
+
+Useful constants:
+
+- `BASE_BUILDER_CODE`
+- `ZKP2P_IOS_REFERRER`
+- `ZKP2P_ANDROID_REFERRER`
+
+## Contract helpers
+
+| Helper | Description |
+| --- | --- |
+| `getContracts(chainId, env?)` | Returns deployed addresses and ABIs for escrow, orchestrator, verifier, ProtocolViewer, USDC, and related contracts |
+| `getRateManagerContracts(chainId, env?)` | Returns rate-manager registry/controller addresses and ABIs |
+| `getPaymentMethodsCatalog(chainId, env?)` | Returns the platform-to-hash catalog used for payment-method resolution |
+| `getGatingServiceAddress(chainId, env?)` | Returns the signer used for intent gating |
+| `HISTORICAL_ESCROW_ADDRESSES` | Historical escrow addresses keyed by runtime deployment |
+
+Common companion helpers:
+
+- `currencyInfo`
+- `getCurrencyInfoFromHash()`
+- `getCurrencyInfoFromCountryCode()`
+- `resolveFiatCurrencyBytes32()`
+- `resolvePaymentMethodHash()`
+- `resolvePaymentMethodHashFromCatalog()`
+- `resolvePaymentMethodNameFromHash()`
+
+## Error handling
+
+All SDK-specific errors extend `ZKP2PError`.
+
+| Class | Code | Extra fields | Use it for |
+| --- | --- | --- | --- |
+| `ZKP2PError` | Any `ErrorCode` | `details?`, `field?` | Shared base class |
+| `ValidationError` | `VALIDATION` | `field?`, `details?` | Invalid input |
+| `NetworkError` | `NETWORK` | `details?` | RPC or network failures |
+| `APIError` | `API` | `status?`, `details?` | Failed API requests |
+| `ContractError` | `CONTRACT` | `details?` | Contract call or simulation failures |
+
+Available error codes: `VALIDATION`, `NETWORK`, `API`, `CONTRACT`, `UNKNOWN`.
+
+```ts
+import {
+  APIError,
+  ContractError,
+  ValidationError,
+  ZKP2PError,
+} from '@zkp2p/sdk';
+
+try {
+  await client.createDeposit({ /* ... */ });
+} catch (error) {
+  if (error instanceof ValidationError) {
+    console.error(error.field, error.message);
+  } else if (error instanceof APIError) {
+    console.error(error.status, error.message);
+  } else if (error instanceof ContractError) {
+    console.error(error.details);
+  } else if (error instanceof ZKP2PError) {
+    console.error(error.code, error.message);
+  }
+}
+```
+
+## Logging
+
+Use `setLogLevel()` to adjust SDK logging.
+
+```ts
+import { setLogLevel } from '@zkp2p/sdk';
+
+setLogLevel('debug'); // 'debug' | 'info' | 'error'
+```
+
+## Help?
+
+If you run into issues, join our [Discord](https://discord.gg/4hNVTv2MbH).

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -1,0 +1,124 @@
+---
+id: sdk-overview
+title: SDK Overview
+slug: /sdk
+---
+
+# SDK Overview
+
+## What this does
+
+`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, and embed the Peer extension onramp. The current npm release is `0.1.0` and is published under the MIT license.
+
+## Who is this for?
+
+| You are building... | Start here | Why |
+| --- | --- | --- |
+| A liquidity provider or off-ramp dashboard | [Offramp Integration](/developer/developer/offramp) | Covers deposit creation, funding, and deposit management end to end |
+| An app that wants to open the Peer extension onramp | [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) | Covers `peerExtensionSdk` and the extension deeplink flow |
+| A custom taker flow, backend, or internal tool | [Client Reference](/developer/sdk/client-reference) | Covers `Zkp2pClient`, intents, quotes, vaults, helpers, and API-backed flows |
+| A React app | [React Hooks](/developer/sdk/react-hooks) | Covers the `@zkp2p/sdk/react` hook layer for transaction UX |
+
+## Installation
+
+Install the core SDK with `viem`. Add `react` only if you plan to use the hooks package.
+
+```bash
+npm install @zkp2p/sdk viem
+# or
+yarn add @zkp2p/sdk viem
+# or
+pnpm add @zkp2p/sdk viem
+# or
+bun add @zkp2p/sdk viem
+```
+
+For hooks:
+
+```bash
+npm install react
+# or
+yarn add react
+# or
+pnpm add react
+# or
+bun add react
+```
+
+:::note
+`viem` is a peer dependency. `react >= 16.8.0` is an optional peer dependency that is only required for `@zkp2p/sdk/react`.
+:::
+
+## Architecture
+
+The SDK is built around RPC-first reads and contract-safe write helpers.
+
+- Common reads such as `getDeposits()`, `getDeposit()`, `getIntents()`, and `getIntent()` use ProtocolViewer and on-chain state first, which helps avoid indexer lag for core flows.
+- Advanced history and filtering live behind `client.indexer.*`, which gives you GraphQL-backed access to richer search, pagination, and fulfillment records.
+- Write methods are split between deposit management, intent operations, and vault/rate-manager flows, with prepared-transaction support for relayers and smart accounts.
+
+### Module map
+
+| Module | What it covers | Start here |
+| --- | --- | --- |
+| `Zkp2pClient` | The canonical SDK client for reads, writes, and API-backed flows | [Client Reference](/developer/sdk/client-reference) |
+| `peerExtensionSdk` | Peer extension detection, connection, and onramp deeplink helpers | [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) |
+| `client.indexer` | Advanced deposit, intent, and fulfillment queries | [Client Reference](/developer/sdk/client-reference#indexer) |
+| Contract helpers | `getContracts`, `getRateManagerContracts`, `getPaymentMethodsCatalog`, `getGatingServiceAddress` | [Client Reference](/developer/sdk/client-reference#contract-helpers) |
+| Currency and payment helpers | `currencyInfo`, `resolveFiatCurrencyBytes32`, payment-method hash helpers | [Client Reference](/developer/sdk/client-reference#contract-helpers) |
+| Attribution and fee helpers | ERC-8021 helpers and referrer fee validation utilities | [Client Reference](/developer/sdk/client-reference#referrer-fees) |
+| React hooks | Transaction-oriented hooks for deposits, intents, and vaults | [React Hooks](/developer/sdk/react-hooks) |
+
+### Entry points
+
+- Import the core SDK from `@zkp2p/sdk`
+- Import hooks from `@zkp2p/sdk/react`
+
+:::info Naming note
+`OfframpClient` is a re-export alias of `Zkp2pClient`. Both names work, but `Zkp2pClient` is the canonical class name used by the published typings and the docs on this page.
+:::
+
+## Quick start
+
+```ts
+import { Zkp2pClient } from '@zkp2p/sdk';
+import { createWalletClient, custom } from 'viem';
+import { base } from 'viem/chains';
+
+const walletClient = createWalletClient({
+  chain: base,
+  transport: custom(window.ethereum),
+});
+
+const client = new Zkp2pClient({
+  walletClient,
+  chainId: base.id,
+  runtimeEnv: 'production',
+  apiKey: 'YOUR_API_KEY',
+});
+
+const deposits = await client.getDeposits();
+console.log(deposits.length);
+```
+
+## Runtime and network selection
+
+The current SDK docs assume Base. Deployment selection is controlled by `chainId` plus `runtimeEnv`.
+
+| Target | `chainId` | `runtimeEnv` | Notes |
+| --- | --- | --- | --- |
+| Base production | `8453` | `production` | Default customer-facing deployment |
+| Base preproduction | `8453` | `preproduction` | Production contracts with preproduction services |
+| Base staging | `8453` | `staging` | Staging services and V2-first routing defaults |
+
+## Recommended starting points
+
+If you are new to the SDK, use this order:
+
+1. Read [Offramp Integration](/developer/developer/offramp) or [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) for an end-to-end flow.
+2. Use [Client Reference](/developer/sdk/client-reference) to look up concrete methods, request shapes, and helper exports.
+3. Use [React Hooks](/developer/sdk/react-hooks) if you want component-level loading, error, and transaction state.
+
+## Help?
+
+If you run into issues, join our [Discord](https://discord.gg/4hNVTv2MbH).

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -14,7 +14,7 @@ slug: /sdk
 
 | You are building... | Start here | Why |
 | --- | --- | --- |
-| A liquidity provider or off-ramp dashboard | [Offramp Integration](/developer/developer/offramp) | Covers deposit creation, funding, and deposit management end to end |
+| A liquidity provider or off-ramp dashboard | [Offramp Integration](/developer/offramp-integration) | Covers deposit creation, funding, and deposit management end to end |
 | An app that wants to open the Peer extension onramp | [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) | Covers `peerExtensionSdk` and the extension deeplink flow |
 | A custom taker flow, backend, or internal tool | [Client Reference](/developer/sdk/client-reference) | Covers `Zkp2pClient`, intents, quotes, vaults, helpers, and API-backed flows |
 | A React app | [React Hooks](/developer/sdk/react-hooks) | Covers the `@zkp2p/sdk/react` hook layer for transaction UX |
@@ -115,7 +115,7 @@ The current SDK docs assume Base. Deployment selection is controlled by `chainId
 
 If you are new to the SDK, use this order:
 
-1. Read [Offramp Integration](/developer/developer/offramp) or [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) for an end-to-end flow.
+1. Read [Offramp Integration](/developer/offramp-integration) or [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) for an end-to-end flow.
 2. Use [Client Reference](/developer/sdk/client-reference) to look up concrete methods, request shapes, and helper exports.
 3. Use [React Hooks](/developer/sdk/react-hooks) if you want component-level loading, error, and transaction state.
 

--- a/developer/sdk/react-hooks.md
+++ b/developer/sdk/react-hooks.md
@@ -1,0 +1,243 @@
+---
+id: sdk-react-hooks
+title: React Hooks
+slug: /sdk/react-hooks
+---
+
+# React Hooks
+
+## What this does
+
+`@zkp2p/sdk/react` wraps the write-heavy parts of `Zkp2pClient` in React-friendly hooks. The hooks manage loading state, errors, and transaction hashes for you, and a subset of them also expose prepared transactions for relayers or smart accounts.
+
+## Installation
+
+Install the core SDK, `viem`, and React:
+
+```bash
+npm install @zkp2p/sdk viem react
+# or
+yarn add @zkp2p/sdk viem react
+# or
+pnpm add @zkp2p/sdk viem react
+# or
+bun add @zkp2p/sdk viem react
+```
+
+`react >= 16.8.0` is an optional peer dependency of `@zkp2p/sdk`.
+
+## Hook pattern
+
+All hooks take an options object with `client` first. Most hooks also accept optional `onSuccess` and `onError` callbacks.
+
+```tsx
+import { useSignalIntent } from '@zkp2p/sdk/react';
+
+function SignalIntentButton({ client, params }) {
+  const {
+    signalIntent,
+    prepareSignalIntent,
+    isLoading,
+    error,
+    txHash,
+    prepared,
+  } = useSignalIntent({ client });
+
+  return (
+    <button
+      disabled={isLoading}
+      onClick={() => signalIntent(params)}
+    >
+      {txHash ?? 'Signal intent'}
+    </button>
+  );
+}
+```
+
+Hooks that expose `prepare...()` return a `PreparedTransaction` in addition to the normal transaction hash flow.
+
+## Deposit hooks
+
+Unless otherwise noted, these hooks use:
+
+```ts
+{ client, onSuccess?, onError? }
+```
+
+| Hook | What it does | Main action(s) | State returned |
+| --- | --- | --- | --- |
+| `useCreateDeposit` | Wraps `client.createDeposit()` | `createDeposit(params)` | `isLoading`, `error`, `txHash`, `depositDetails` |
+| `useAddFunds` | Wraps `client.addFunds()` | `addFunds(params)` | `isLoading`, `error`, `txHash` |
+| `useRemoveFunds` | Wraps `client.removeFunds()` | `removeFunds(params)` | `isLoading`, `error`, `txHash` |
+| `useWithdrawDeposit` | Wraps `client.withdrawDeposit()` | `withdrawDeposit(params)` | `isLoading`, `error`, `txHash` |
+| `useSetAcceptingIntents` | Wraps `client.setAcceptingIntents()` | `setAcceptingIntents(params)` | `isLoading`, `error`, `txHash` |
+| `useSetIntentRange` | Wraps `client.setIntentRange()` | `setIntentRange(params)` | `isLoading`, `error`, `txHash` |
+| `useSetCurrencyMinRate` | Wraps `client.setCurrencyMinRate()` | `setCurrencyMinRate(params)` | `isLoading`, `error`, `txHash` |
+| `useSetRetainOnEmpty` | Wraps `client.setRetainOnEmpty()` | `setRetainOnEmpty(params)` | `isLoading`, `error`, `txHash` |
+| `useSetDelegate` | Wraps `client.setDelegate()` | `setDelegate(params)` | `isLoading`, `error`, `txHash` |
+| `useRemoveDelegate` | Wraps `client.removeDelegate()` | `removeDelegate(params)` | `isLoading`, `error`, `txHash` |
+
+## Intent hooks
+
+| Hook | What it does | Main action(s) | State returned |
+| --- | --- | --- | --- |
+| `useSignalIntent` | Wraps `client.signalIntent()` | `signalIntent(params)`, `prepareSignalIntent(params)` | `isLoading`, `error`, `txHash`, `prepared` |
+| `useFulfillIntent` | Wraps `client.fulfillIntent()` | `fulfillIntent(params)`, `prepareFulfillIntent(params)` | `isLoading`, `error`, `txHash`, `prepared` |
+| `useReleaseFundsToPayer` | Wraps `client.releaseFundsToPayer()` | `releaseFundsToPayer(params)` | `isLoading`, `error`, `txHash` |
+| `usePruneExpiredIntents` | Wraps `client.pruneExpiredIntents()` | `pruneExpiredIntents(params)` | `isLoading`, `error`, `txHash` |
+
+:::note
+The hooks package does not currently export `useCancelIntent`. If you need cancel flows in React, call `client.cancelIntent()` or `client.cancelIntent.prepare()` directly.
+:::
+
+## Vault hooks
+
+### `useCreateVault`
+
+This hook provides a vault-friendly wrapper around `client.createRateManager()`.
+
+**Options**
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `client` | Yes | `Zkp2pClient` instance |
+| `sendTransaction` | Yes | Callback that sends a prepared transaction and returns a hash |
+| `referrer` | No | Single referrer code or list of referrer codes for attribution |
+| `onSuccess` | No | Success callback |
+| `onError` | No | Error callback |
+
+**Call signature**
+
+```ts
+createVault({
+  config: {
+    manager,
+    feeRecipient,
+    maxFee,
+    fee,
+    depositHook?,
+    minLiquidity?,
+    name,
+    uri,
+  },
+})
+```
+
+**Returns**
+
+`useCreateVault()` returns `createVault`, `prepareCreateVault`, `isLoading`, `error`, and `txHash`.
+
+### `useVaultDelegation`
+
+This hook chooses the correct delegation path for you and supports optional batching.
+
+**Options**
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `client` | Yes | `Zkp2pClient` instance |
+| `sendTransaction` | Yes | Single-transaction sender |
+| `sendBatch` | No | Batch sender for smart-account or user-op flows |
+| `referrer` | No | Single referrer code or list of referrer codes |
+| `onSuccess` | No | Success callback |
+| `onError` | No | Error callback |
+
+**Main actions**
+
+| Action | Use it for |
+| --- | --- |
+| `delegateDeposit({ escrow, depositId, registry, rateManagerId, currentRateManagerId?, currentRateManagerRegistry?, preflightHook? })` | Delegate one deposit |
+| `delegateDeposits({ registry, rateManagerId, deposits, preflightHook? })` | Delegate many deposits |
+| `clearDelegation({ escrow, depositId })` | Clear one delegation |
+| `clearDelegations({ deposits })` | Clear many delegations |
+
+**Returns**
+
+`useVaultDelegation()` returns the four actions above plus `isLoading` and `error`.
+
+### Vault settings hooks
+
+| Hook | What it does | Main action(s) | State returned |
+| --- | --- | --- | --- |
+| `useSetVaultFee` | Wraps `client.setVaultFee()` | `setVaultFee(params)`, `prepareSetVaultFee(params)` | `isLoading`, `error`, `txHash`, `prepared` |
+| `useSetVaultMinRate` | Wraps `client.setVaultMinRate()` | `setVaultMinRate(params)`, `prepareSetVaultMinRate(params)` | `isLoading`, `error`, `txHash`, `prepared` |
+| `useSetVaultConfig` | Wraps `client.setVaultConfig()` | `setVaultConfig(params)`, `prepareSetVaultConfig(params)` | `isLoading`, `error`, `txHash`, `prepared` |
+
+## Payment method hooks
+
+| Hook | What it does | Main action(s) | State returned |
+| --- | --- | --- | --- |
+| `useAddPaymentMethods` | Wraps `client.addPaymentMethods()` | `addPaymentMethods(params)` | `isLoading`, `error`, `txHash` |
+| `useSetPaymentMethodActive` | Wraps `client.setPaymentMethodActive()` | `setPaymentMethodActive(params)` | `isLoading`, `error`, `txHash` |
+| `useRemovePaymentMethod` | Wraps `client.removePaymentMethod()` | `removePaymentMethod(params)` | `isLoading`, `error`, `txHash` |
+
+## Currency hooks
+
+| Hook | What it does | Main action(s) | State returned |
+| --- | --- | --- | --- |
+| `useAddCurrencies` | Wraps `client.addCurrencies()` | `addCurrencies(params)` | `isLoading`, `error`, `txHash` |
+| `useDeactivateCurrency` | Wraps `client.deactivateCurrency()` | `deactivateCurrency(params)` | `isLoading`, `error`, `txHash` |
+| `useRemoveCurrency` | Wraps `client.removeCurrency()` | `removeCurrency(params)` | `isLoading`, `error`, `txHash` |
+
+## Query hooks
+
+The hooks package currently exposes one read-oriented hook.
+
+### `useGetTakerTier`
+
+**Options**
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `client` | Yes | `Zkp2pClient` instance |
+| `owner` | No | Address to auto-fetch for |
+| `chainId` | No | Chain ID to auto-fetch for |
+| `autoFetch` | No | Automatically fetch when `owner` and `chainId` are present |
+| `onSuccess` | No | Success callback |
+| `onError` | No | Error callback |
+
+**Returns**
+
+`useGetTakerTier()` returns `getTakerTier(params?)`, `takerTier`, `isLoading`, and `error`.
+
+### Tier helper utilities
+
+| Utility | Purpose |
+| --- | --- |
+| `getTierDisplayInfo(tier)` | Maps a raw tier response to UI-friendly labels and cap display |
+| `getNextTierCap(currentTier)` | Returns the next cap threshold for the supplied tier |
+
+## Vault utilities
+
+The hooks package re-exports several delegation helpers and types.
+
+| Export | Purpose |
+| --- | --- |
+| `ZERO_RATE_MANAGER_ID` | Canonical zero vault ID |
+| `isZeroRateManagerId(value)` | Checks whether a vault ID is the zero ID |
+| `normalizeRateManagerId(value)` | Normalizes a vault ID string |
+| `normalizeRegistry(value)` | Normalizes a registry address string |
+| `getDelegationRoute(client, escrow)` | Returns whether the deposit should use the `legacy` or `v2` delegation path |
+| `classifyDelegationState(currentRateManagerId, currentRegistry, targetRateManagerId, targetRegistry)` | Classifies whether a deposit is delegated here, elsewhere, or not delegated |
+
+Useful exported types:
+
+- `DelegationRoute`
+- `DelegationState`
+- `DelegationDepositTarget`
+- `BatchResult`
+- `SendTransactionFn`
+- `SendBatchFn`
+
+## When to use hooks vs the core client
+
+Use hooks when you want component-local transaction state. Use the core client directly when you need:
+
+- quote lookups with `getQuote()`
+- RPC-first reads such as `getDeposits()` and `getIntent()`
+- indexer queries through `client.indexer`
+- client methods that do not have a React wrapper yet
+
+## Help?
+
+If you run into issues, join our [Discord](https://discord.gg/4hNVTv2MbH).


### PR DESCRIPTION
## Summary

- Add three new SDK documentation pages: overview, client reference (`Zkp2pClient` API), and React hooks (`@zkp2p/sdk/react`)
- Add "SDK Reference" category to the developer sidebar with links to all three pages
- Covers constructor options, deposit/intent/quote/vault methods, helpers, and React hook APIs

## Test plan

- [ ] Run `yarn build` and verify no broken links or missing doc IDs
- [ ] Navigate to `/developer/sdk` and confirm overview, client reference, and React hooks pages render correctly
- [ ] Verify sidebar shows the new "SDK Reference" category with sub-items