### PR TITLE
docs: update protocol docs for V3 contract upgrade

### DIFF
--- a/protocol-sidebars.js
+++ b/protocol-sidebars.js
@@ -18,7 +18,8 @@ module.exports = {
           items: [
             'v3/smart-contracts/escrow/index',
             'v3/smart-contracts/orchestrator',
-            'v3/smart-contracts/post-intent-hooks',
+            'v3/smart-contracts/pre-intent-hooks',
+            { type: 'doc', id: 'v3/smart-contracts/post-intent-hooks', label: 'Post-Intent Hooks' },
             'v3/smart-contracts/unified-payment-verifier',
           ],
         },

--- a/protocol/CLAUDE.md
+++ b/protocol/CLAUDE.md
@@ -20,7 +20,7 @@ Two protocol versions are documented:
 | Version | Status | Deployment | Key Difference |
 |---------|--------|------------|----------------|
 | **V3** | Current | Base mainnet | Off-chain attestation service, unified verifier |
-| **V2** | Legacy | Sepolia testnet | On-chain per-platform verifiers |
+| **V2** | Legacy | Base mainnet | On-chain per-platform verifiers |
 
 ### V3 Architecture (Current)
 

--- a/protocol/gating-service.md
+++ b/protocol/gating-service.md
@@ -11,6 +11,15 @@ The Gating Service has 2 roles
 
 2.  Store offchain payment identifiers (e.g. Venmo User ID) in the deposit flow for sellers to introduce a layer of privacy to the blockchain
 
+### On-Chain Pre-Intent Hooks
+
+V3 also supports on-chain deposit-level access control via pre-intent hooks on OrchestratorV2. These provide an alternative or complement to the off-chain gating service:
+
+- **SignatureGatingPreIntentHook**: Requires an EIP-191 signature from a configurable signer per deposit — similar to the off-chain gating service but enforced on-chain.
+- **WhitelistPreIntentHook**: Restricts intents to a whitelisted set of taker addresses per deposit and payment method.
+
+See [Pre-Intent Hooks](/protocol/v3/smart-contracts/pre-intent-hooks) for details.
+
 ### API Reference
 
 Our current gating service API is hosted at api.peer.xyz

--- a/protocol/v2/smart-contracts/deployments.md
+++ b/protocol/v2/smart-contracts/deployments.md
@@ -64,39 +64,6 @@ title: Deployments
   </tbody>
 </table>
 
-## Sepolia Testnet 
-
-<table>
-  <thead>
-    <tr>
-      <th>Contract Name</th>
-      <th>Address</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Escrow</td>
-      <td><a href="https://sepolia.etherscan.io/address/0xFF0149799631D7A5bdE2e7eA9b306c42b3d9a9ca">0xFF0149799631D7A5bdE2e7eA9b306c42b3d9a9ca</a></td>
-    </tr>
-    <tr>
-      <td>NullifierRegistry</td>
-      <td><a href="https://sepolia.etherscan.io/address/0x9cF61278C2Cc9C41578fE3a0ED375E9870D514F1">0x9cF61278C2Cc9C41578fE3a0ED375E9870D514F1</a></td>
-    </tr>
-    <tr>
-      <td>VenmoReclaimVerifier</td>
-      <td><a href="https://sepolia.etherscan.io/address/0x3Fa6C4135696fBD99F7D55B552B860f5df770710">0x3Fa6C4135696fBD99F7D55B552B860f5df770710</a></td>
-    </tr>
-    <tr>
-      <td>RevolutReclaimVerifier</td>
-      <td><a href="https://sepolia.etherscan.io/address/0x79820f039942501F412910C083aDA6dCc419B67c">0x79820f039942501F412910C083aDA6dCc419B67c</a></td>
-    </tr>
-    <tr>
-      <td>CashappReclaimVerifier</td>
-      <td><a href="https://sepolia.etherscan.io/address/0x3997dd7B691E11D45E8898601F5bc7B016b0d38B">0x3997dd7B691E11D45E8898601F5bc7B016b0d38B</a></td>
-    </tr>
-  </tbody>
-</table>
-
 ## Supported Currencies
 
 <table>

--- a/protocol/v3/attestation-service.md
+++ b/protocol/v3/attestation-service.md
@@ -121,5 +121,5 @@ const paymentProof = ethers.AbiCoder.defaultAbiCoder().encode([
 2) Call `fulfillIntent` with `paymentProof` and the on-chain `intentHash`.
 
 Choosing `chainId` and `verifyingContract`
-- `chainId` must match the destination chain where `UnifiedPaymentVerifier` lives.
-- `verifyingContract` is the on-chain `UnifiedPaymentVerifier` address; it is part of the EIP‑712 domain and must match exactly.
+- `chainId` must match the destination chain where `UnifiedPaymentVerifierV2` lives.
+- `verifyingContract` is the on-chain `UnifiedPaymentVerifierV2` address (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` on Base); it is part of the EIP‑712 domain and must match exactly.

--- a/protocol/v3/deployments.md
+++ b/protocol/v3/deployments.md
@@ -13,22 +13,62 @@ Note: We do not have a Sepolia deployment for V3.
 
 ### Contracts
 
+V3 contracts (EscrowV2, OrchestratorV2) are the production system. Legacy contracts still hold active deposits but are deprecated and will be wound down.
+
+#### V3 Core
+
+| Contract | Address |
+| --- | --- |
+| EscrowV2 | `0x777777779d229cdF3110e9de47943791c26300Ef` |
+| OrchestratorV2 | `0x888888359E981B5225CA48fbCdCeff702FC3b888` |
+| RateManagerV1 | `0xeEd7Db23e724aC4590D6dB6F78fDa6DB203535F3` |
+| ProtocolViewerV2 | `0xC8A622e1614BB58141E72e1D6023B16f08677d6c` |
+
+#### Registries
+
+| Contract | Address |
+| --- | --- |
+| EscrowRegistry | `0xeD0e847B101abc96E796260AC358e12BAa2f5B21` |
+| OrchestratorRegistry | `0xBe9fED15ED7A4B915C03EFcEcb9662739C3382A9` |
+| PaymentVerifierRegistry | `0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e` |
+| NullifierRegistry | `0x8d8e1A0e5345a5cc9AA206c3ca76D6d28c514608` |
+| RelayerRegistry | `0xEbA979889a9c97382A92472fF3703786fF180083` |
+
+#### Verification
+
+| Contract | Address |
+| --- | --- |
+| UnifiedPaymentVerifierV2 | `0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` |
+| SimpleAttestationVerifier | `0xED6C0C34c3964D239e7a315C55E620fafE5Ae3AC` |
+
+#### Hooks
+
+| Contract | Address |
+| --- | --- |
+| SignatureGatingPreIntentHook | `0x62D410a3d6FC766dd2192be2a67a5fc79c5c2e1F` |
+| WhitelistPreIntentHook | `0xd793369b11357cdd076A9c631F6c44ff8e6353eA` |
+| AcrossBridgeHookV2 | `0xCcC9163451DE31a625D48e417e0fD1a329c7f7cf` |
+
+#### Oracles
+
+| Contract | Address |
+| --- | --- |
+| ChainlinkOracleAdapter | `0x53881a928abD61C095e5f30b63bc554872C3b2f1` |
+
+#### Legacy (Deprecated)
+
 | Contract | Address |
 | --- | --- |
 | Escrow | `0x2f121CDDCA6d652f35e8B3E560f9760898888888` |
 | Orchestrator | `0x88888883Ed048FF0a415271B28b2F52d431810D0` |
-| EscrowRegistry | `0xeD0e847B101abc96E796260AC358e12BAa2f5B21` |
-| NullifierRegistry | `0x8d8e1A0e5345a5cc9AA206c3ca76D6d28c514608` |
-| PaymentVerifierRegistry | `0x2b82D24437ff66Fb173eabDfD67ee2ACeb8bEb1e` |
-| PostIntentHookRegistry | `0x9B128EBAD4d874199A2Dc57E93186796c5EcAdE9` |
-| ProtocolViewer | `0x30B03De22328074Fbe8447C425ae988797146606` |
-| RelayerRegistry | `0xEbA979889a9c97382A92472fF3703786fF180083` |
-| SimpleAttestationVerifier | `0xED6C0C34c3964D239e7a315C55E620fafE5Ae3AC` |
 | UnifiedPaymentVerifier | `0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163` |
+| PostIntentHookRegistry | `0x9B128EBAD4d874199A2Dc57E93186796c5EcAdE9` |
+| AcrossBridgeHook | `0x72C10b838Cf46649691949c285E0b468b363b9f0` |
+| ProtocolViewer | `0x30B03De22328074Fbe8447C425ae988797146606` |
 
 ### Payment Methods
 
-All payment methods resolve to the same verifier contract on Base: `UnifiedPaymentVerifier` at `0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163`.
+All payment methods resolve to the same verifier contract on Base: `UnifiedPaymentVerifierV2` at `0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94`.
 
 | Payment Method | Payment Method ID (bytes32) | Supported Currencies |
 | --- | --- | --- |
@@ -43,10 +83,9 @@ All payment methods resolve to the same verifier contract on Base: `UnifiedPayme
 | paypal | `0x3ccc3d4d5e769b1f82dc4988485551dc0cd3c7a3926d7d8a4dde91507199490f` | USD, EUR, GBP, SGD, NZD, AUD, CAD |
 | monzo | `0x62c7ed738ad3e7618111348af32691b5767777fbaf46a2d8943237625552645c` | GBP |
 | n26 | `0xd9ff4fd6b39a3e3dd43c41d05662a5547de4a878bc97a65bcb352ade493cdc6b` | EUR |
+| alipay | `0xcac9daea62d7b89d75ac73af4ee14dcf25721012ae82b568c2ea5c808eaa04ff` | CNY |
 | chime | `0x5908bb0c9b87763ac6171d4104847667e7f02b4c47b574fe890c1f439ed128bb` | USD |
-
-
-
+| luxon | `0xaea63ef983458674f54ee50cdaa7b09d80a5c6c03ed505f51c90b0f2b54abb01` | USD, EUR, GBP |
 
 ### All Supported Currencies
 
@@ -90,6 +129,6 @@ Currency codes are ISO 4217 (uppercase). The on-chain representation is the byte
 
 ### Notes
 
-- All payment methods are registered in `PaymentVerifierRegistry` and resolve to the same `UnifiedPaymentVerifier` address on Base.
+- All payment methods are registered in `PaymentVerifierRegistry` and resolve to the same `UnifiedPaymentVerifierV2` address on Base.
 - Currencies per method are derived from the latest snapshots under `deployments/outputs/platforms/snapshots/base`. If these change, update this document by re-reading those files.
-- Last refresh: 2025-10-27 (UTC)
+- Last refresh: 2026-03-17 (UTC)

--- a/protocol/v3/deployments.md
+++ b/protocol/v3/deployments.md
@@ -3,7 +3,7 @@ id: v3-deployments
 title: V3 Deployments
 ---
 
-Note: We do not have a Sepolia deployment for V3.
+Note: All deployments are on Base mainnet. Staging uses a separate deployer on the same chain.
 
 ## Base (Mainnet)
 

--- a/protocol/v3/migration.md
+++ b/protocol/v3/migration.md
@@ -23,7 +23,7 @@ This guide helps integrators move from the V2 proof flow to the V3 attestation f
 - PeerAuth: proof generation UX and API are the same.
 - Currency/method hashing: still keccak256 bytes32 on-chain.
 
-### API changes you’ll notice
+### API changes you'll notice
 - Gating (Curator): use the v2 verify endpoint with the expanded request.
 - Quoter: response now includes deposit success metrics and optional filters.
 
@@ -34,3 +34,31 @@ This guide helps integrators move from the V2 proof flow to the V3 attestation f
 - Fulfill
   - V2: `Escrow.fulfillIntent(bytes proof, bytes32 intentHash)` with proof JSON bytes
   - V3: `Orchestrator.fulfillIntent({ paymentProof: abi.encode(PaymentAttestation), intentHash, verificationData, postIntentHookData })`
+
+---
+
+### V3 Contract Upgrade
+
+The V3 contracts were upgraded from Escrow/Orchestrator to EscrowV2/OrchestratorV2. If you integrated against the original V3 contracts, here are the breaking changes:
+
+**Intent Parameters**
+- `referrer` (address) + `referrerFee` (uint256) → `referralFees[]` (array of `IReferralFee.ReferralFee`). Supports multiple referral recipients with individual fees.
+- `IPostIntentHook postIntentHook` → `IPostIntentHookV2 postIntentHook`. The V2 hook interface uses `HookExecutionContext` instead of `(Intent, amountNetFees, data)`.
+- New field: `bytes preIntentHookData` — Ephemeral data passed to pre-intent hooks during signalIntent.
+
+**New Escrow Address**
+- New deposits should go to EscrowV2 (`0x777777779d229cdF3110e9de47943791c26300Ef`).
+- The legacy Escrow (`0x2f121CDDCA6d652f35e8B3E560f9760898888888`) still holds active deposits but is deprecated.
+
+**Orchestrator Authorization**
+- `OrchestratorRegistry` replaces the single `orchestrator` address on Escrow. Multiple orchestrators can be authorized on EscrowV2.
+- Use OrchestratorV2 (`0x888888359E981B5225CA48fbCdCeff702FC3b888`) for new intents.
+
+**Verification**
+- `UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94`) is the production verifier. The legacy `UnifiedPaymentVerifier` is only used by the deprecated Orchestrator.
+
+**New Optional Features**
+- Pre-intent hooks: two hook slots per deposit (generic + whitelist) for on-chain access control. See [Pre-Intent Hooks](./smart-contracts/pre-intent-hooks.md).
+- Oracle rate configuration: per-currency oracle adapters for automatic rate floor adjustment.
+- Delegated rate management: opt into RateManagerV1 for programmatic rate updates with fee sharing.
+- Manager fees: rate managers can charge fees (capped at 5%) distributed at fulfillment.

--- a/protocol/v3/overview.md
+++ b/protocol/v3/overview.md
@@ -5,30 +5,40 @@ title: ZKP2P Protocol V3 — Overview
 
 # ZKP2P Protocol V3 — Overview
 
-ZKP2P V3 makes the protocol faster, more flexible, and easier to integrate by moving proof verification off-chain into a standardized Attestation Service, and by consolidating on-chain verification logic into a single Unified Payment Verifier. The protocol remains fully non-custodial: contracts only move funds, while verification and orchestration are modular and replaceable.
+ZKP2P V3 is the current production protocol. It enables faster, more flexible, and easier-to-integrate P2P exchange by moving proof verification off-chain into a standardized Attestation Service, and by consolidating on-chain verification logic into a single Unified Payment Verifier. The protocol remains fully non-custodial: contracts only move funds, while verification and orchestration are modular and replaceable.
 
-### What’s new vs V2
-- Off-chain verification: the Attestation Service validates provider proofs (e.g., Reclaim/TLSNotary), normalizes them, and signs an EIP‑712 PaymentAttestation used on-chain.
-- Single on-chain verifier: `UnifiedPaymentVerifier` validates the EIP‑712 signature and enforces protocol rules (intent bounds, nullifiers, release capping).
+### What's new vs V2
+- Off-chain verification: the Attestation Service validates provider proofs (e.g., Reclaim/TLSNotary), normalizes them, and signs an EIP-712 PaymentAttestation used on-chain.
+- Single on-chain verifier: `UnifiedPaymentVerifierV2` validates the EIP-712 signature and enforces protocol rules (intent bounds, nullifiers, release capping).
 - Cleaner intent path: the gating service signs intents with richer context (payment method, fiat currency, conversion rate, orchestrator/escrow addresses) to reduce round trips.
 - Extensible: adding providers is purely off-chain (transformers) with a stable on-chain attestation format.
+- Oracle-driven rate floors: depositors can configure oracle adapters (Chainlink) per currency to auto-adjust minimum conversion rates based on market prices.
+- Delegated rate management: depositors can opt into external rate managers (RateManagerV1) that set rates on their behalf, enabling programmatic rate updates with fee sharing.
+- Pre-intent hooks: two dedicated hook slots per deposit (generic + whitelist) that run before state changes during `signalIntent`. Enable on-chain gating (signature validation, address whitelists) without the off-chain gating service.
+- Manager fees: rate managers can charge fees (capped at 5%) snapshotted at signal time and distributed at fulfillment.
+- Multi-recipient referral fees: `referralFees[]` array replaces the single `referrer` + `referrerFee` fields.
+- Multi-orchestrator support: `OrchestratorRegistry` allows multiple orchestrator contracts to interact with EscrowV2, replacing the single orchestrator address pattern.
 
 ### Flow
-- Buyer (on‑ramper): pays off-chain and receives on-chain tokens.
-- Seller (off‑ramper): supplies token liquidity in Escrow and receives off-chain fiat.
+- Buyer (on-ramper): pays off-chain and receives on-chain tokens.
+- Seller (off-ramper): supplies token liquidity in Escrow and receives off-chain fiat.
 - Gating Service (Curator): authorizes intent creation for sellers, returns payee details and a signature.
 - Attestation Service: verifies provider proofs and issues PaymentAttestations.
-- On-chain: Escrow, Orchestrator, UnifiedPaymentVerifier, AttestationVerifier (witness set).
+- On-chain: EscrowV2, OrchestratorV2, OrchestratorRegistry, RateManagerV1, UnifiedPaymentVerifierV2, AttestationVerifier (witness set).
+- Pre-intent hooks run before fund locking during `signalIntent`.
 
-###High‑level flow
-1) Quote: client fetches quotes (developer docs cover API). 
+### High-level flow
+1) Quote: client fetches quotes (developer docs cover API).
 2) Intent signing: client calls the gating API (Curator v2 endpoint) to obtain `gatingServiceSignature` tied to deposit/payment method/fiat.
-3) Signal Intent (on-chain): call `Orchestrator.signalIntent(...)` with depositId, amount, to, paymentMethod, fiatCurrency, conversionRate, `gatingServiceSignature`.
-4) Pay off‑chain: buyer pays seller’s off-chain identifier (hashed on-chain as `payeeDetails`).
+3) Signal Intent (on-chain): call `OrchestratorV2.signalIntent(...)` with depositId, amount, to, paymentMethod, fiatCurrency, conversionRate, referralFees, `gatingServiceSignature`. Pre-intent hooks validate the intent before state changes.
+4) Pay off-chain: buyer pays seller's off-chain identifier (hashed on-chain as `payeeDetails`).
 5) Generate proof: via PeerAuth; send proof + intent details to Attestation Service.
-6) Attestation: Attestation Service returns a `PaymentAttestation` EIP‑712 signature and an ABI-encoded payload.
-7) Fulfill (on‑chain): call `Orchestrator.fulfillIntent({ paymentProof: abi.encode(PaymentAttestation), intentHash, ... })`. Orchestrator routes to `UnifiedPaymentVerifier` to check the attestation, then unlocks and transfers tokens.
+6) Attestation: Attestation Service returns a `PaymentAttestation` EIP-712 signature and an ABI-encoded payload.
+7) Fulfill (on-chain): call `OrchestratorV2.fulfillIntent({ paymentProof: abi.encode(PaymentAttestation), intentHash, ... })`. Orchestrator routes to `UnifiedPaymentVerifierV2` to check the attestation, then unlocks and transfers tokens.
 
 ### Trust model
 - Off-chain witnesses: Attestation Service signatures are verified on-chain by `AttestationVerifier` (e.g., `SimpleAttestationVerifier` with a witness key). Witness rotation is on-chain governed.
 - Intent integrity: snapshot values in the attestation are checked against on-chain intent state; nullifiers prevent double-spend; release amount is capped to the signaled amount.
+- Oracle adapter safety: oracle adapters are view-only (no state mutation). Staleness checks ensure stale data is rejected. Oracle rates can only raise the floor, never lower it below the fixed rate.
+- Pre-intent hook constraints: hooks can only revert to reject. They cannot modify state or approve intents conditionally — it's pass/fail.
+- Manager fee caps: manager fees are capped at 5% (`MAX_MANAGER_FEE = 5e16`) and snapshotted at signal time so they cannot be changed retroactively.

--- a/protocol/v3/smart-contracts.md
+++ b/protocol/v3/smart-contracts.md
@@ -8,17 +8,24 @@ title: Smart Contracts
 This page summarizes the V3 on-chain contracts and links to detailed pages for each component.
 
 ### Orchestrator
-- Purpose: lifecycle for intents (signal, fulfill), protocol/referrer fees, routing to verifiers, and post-intent hooks.
+
+- Purpose: lifecycle for intents (signal, fulfill), protocol/referral/manager fees, routing to verifiers, pre-intent hooks, and post-intent hooks.
 - Key entry points
   - `signalIntent(SignalIntentParams)`
-    - Inputs: `escrow`, `depositId`, `amount`, `to`, `paymentMethod` (bytes32), `fiatCurrency` (bytes32), `conversionRate` (1e18 fixed), `referrer`, `referrerFee`, `gatingServiceSignature`, `signatureExpiration`, optional `postIntentHook`, `data`.
+    - Inputs: `escrow`, `depositId`, `amount`, `to`, `paymentMethod` (bytes32), `fiatCurrency` (bytes32), `conversionRate` (1e18 fixed), `referralFees[]` (multi-recipient), `gatingServiceSignature`, `signatureExpiration`, optional `postIntentHook` (IPostIntentHookV2), `preIntentHookData`, `data`.
+    - Pre-intent hooks (generic + whitelist) execute before state changes.
+    - Manager fee is snapshotted from `EscrowV2.getManagerFee(depositId)`.
+    - `intentMinAtSignal` is snapshotted from the deposit's min intent amount.
     - Emits `IntentSignaled(intentHash, escrow, depositId, paymentMethod, owner, to, amount, fiatCurrency, conversionRate, timestamp)`.
   - `fulfillIntent(FulfillIntentParams)`
     - Inputs: `paymentProof` (ABI-encoded `PaymentAttestation`), `intentHash`, optional `verificationData`, optional `postIntentHookData`.
-    - Routes to the configured `IPaymentVerifier`, unlocks funds, transfers net of fees, and emits `IntentFulfilled`.
+    - Routes to the configured `IPaymentVerifier`, unlocks funds, distributes fees (protocol → manager → referral), and transfers net to `to` or post-intent hook.
+    - Enforces `intentMinAtSignal` — prevents sub-minimum partial fulfillments.
+    - Emits `IntentFulfilled`.
 
 ### UnifiedPaymentVerifier
 - Purpose: canonical on-chain verifier for off-chain attestations.
+- V3 uses `UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94`).
 - Typed data
   - Type: `PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)`
   - Domain: name `UnifiedPaymentVerifier`, version `1`, chainId, verifyingContract.
@@ -39,7 +46,7 @@ This page summarizes the V3 on-chain contracts and links to detailed pages for e
       - `intentHash`, `amount`, `paymentMethod`, `fiatCurrency`, `payeeDetails`, `conversionRate`, `signalTimestamp`, `timestampBuffer`
 
 ### Verification rules (key checks)
-- EIP‑712 signature validates over `(intentHash, releaseAmount, dataHash)` and the domain separator.
+- EIP-712 signature validates over `(intentHash, releaseAmount, dataHash)` and the domain separator.
 - `keccak256(data) == dataHash` to prevent tampering.
 - Snapshot must match on-chain intent fields at fulfillment time.
 - Nullifier: `keccak256(paymentMethod || paymentId)` must be unused; it is recorded to prevent reuse.
@@ -50,11 +57,40 @@ This page summarizes the V3 on-chain contracts and links to detailed pages for e
 - Governance can update the witness set; threshold defaults to 1 in `SimpleAttestationVerifier`.
 
 ### Escrow
-- Holds deposits and tracks payment methods + currencies per deposit.
-- Orchestrator calls into Escrow to lock/unlock and transfer funds.
+- EscrowV2 holds deposits and tracks payment methods + currencies per deposit.
+- Supports oracle-driven rate floors, delegated rate management (RateManagerV1), dust sweeping, and third-party funded deposits (`depositTo`).
+- Authorized Orchestrators (via OrchestratorRegistry) call into Escrow to lock/unlock and transfer funds.
+
+### OrchestratorRegistry
+- Simple allowlist authorizing orchestrator contracts on EscrowV2.
+- `addOrchestrator(address)` / `removeOrchestrator(address)` — Owner-only.
+- `isOrchestrator(address)` — Returns whether an address is authorized.
+- Replaces the single `orchestrator` address used in the legacy Escrow.
+
+### RateManagerV1
+- Pure rate registry for delegated rate management.
+- Managers create configs (`createRateManager`), set rates per deposit/method/currency.
+- Exposes `getRate(rateManagerId, escrow, depositId, paymentMethod, currencyCode)` and `getFee(rateManagerId)`.
+- EscrowV2 enforces the effective rate floor as `max(fixedRate, oracleRate, delegatedRate)`.
+- Manager fee (capped at 5%) is snapshotted at intent signal time and distributed at fulfillment.
+
+### ChainlinkOracleAdapter
+- Wraps Chainlink price feeds implementing `IOracleAdapter`.
+- `getRate(normalizedConfig)` → `(isValid, marketRate, updatedAt)`.
+- `validateConfig(rawConfig)` — Validates and normalizes adapter-specific config for storage.
+- Adapters are view-only (no state mutation) and normalize rates to 1e18 preciseUnits.
+- Spread is applied by EscrowV2, not the adapter: `oracleRate = marketRate * (10_000 + spreadBps) / 10_000`.
+
+### Pre-Intent Hooks
+- Two dedicated hook slots per deposit on OrchestratorV2: generic pre-intent hook + whitelist hook.
+- Run during `signalIntent` before state changes. Can only revert to reject.
+- Built-in implementations: `SignatureGatingPreIntentHook` (EIP-191 signature gating), `WhitelistPreIntentHook` (address whitelist).
+- See [Pre-Intent Hooks](./smart-contracts/pre-intent-hooks.md) for details.
 
 ### Events (selected)
-- `IntentSignaled`, `IntentFulfilled`, `PaymentMethodAdded/Removed`, `AttestationVerifierUpdated`.
+- `IntentSignaled`, `IntentFulfilled`, `IntentPruned`, `IntentReferralFeeDistributed`, `IntentManagerFeeSnapshotted`
+- `DepositPreIntentHookSet`, `DepositWhitelistHookSet`
+- `PaymentMethodAdded/Removed`, `AttestationVerifierUpdated`.
 
 Notes
 - All string-like identifiers (payment method, currency code, payee id, payment id) are keccak256-hashed to bytes32 on-chain.

--- a/protocol/v3/smart-contracts/escrow/index.md
+++ b/protocol/v3/smart-contracts/escrow/index.md
@@ -4,33 +4,43 @@ title: Escrow
 
 ## Overview
 
-The Escrow contract in V3 focuses on deposits and token custody. It lets sellers configure supported payment methods (bytes32), currencies and minimum conversion rates, and manages locking/unlocking when intents are signaled/fulfilled via the Orchestrator.
+The Escrow contract (EscrowV2) in V3 focuses on deposits and token custody. It lets sellers configure supported payment methods (bytes32), currencies and minimum conversion rates, and manages locking/unlocking when intents are signaled/fulfilled via authorized Orchestrators.
 
-Compared to older versions, Escrow no longer verifies payments directly or manages the full intent lifecycle — that responsibility moved to the Orchestrator.
+Compared to older versions, Escrow no longer verifies payments directly or manages the full intent lifecycle — that responsibility moved to the Orchestrator. EscrowV2 also introduces oracle-driven rate floors, delegated rate management, dust sweeping, and multi-orchestrator support via OrchestratorRegistry.
 
 ---
 
 ## Constants
 
 - `uint256 internal constant PRECISE_UNIT = 1e18;`
+- `uint256 internal constant BPS = 10_000;`
+- `int256 internal constant SIGNED_BPS = 10_000;`
 - `uint256 internal constant MAX_DUST_THRESHOLD = 1e6; // 1 USDC`
 - `uint256 internal constant MAX_TOTAL_INTENT_EXPIRATION_PERIOD = 5 days;`
+- `uint256 internal constant MAX_ADAPTER_CONFIG_BYTES = 256;`
 
 ---
 
 ## Key State
 
-- `IOrchestrator public orchestrator` — Orchestrator contract authorized to lock/unlock.
-- `IPaymentVerifierRegistry public paymentVerifierRegistry` — registry providing allowed payment methods/currencies.
-- `uint256 public immutable chainId` — deployment chain id.
-- `mapping(address => uint256[]) accountDeposits` — deposit ids per account.
-- `mapping(uint256 => Deposit) deposits` — core deposit data:
+- `IOrchestratorRegistry public orchestratorRegistry` — Registry of authorized orchestrator contracts that can lock/unlock funds.
+- `IPaymentVerifierRegistry public paymentVerifierRegistry` — Registry providing allowed payment methods/currencies.
+- `uint256 public immutable chainId` — Deployment chain id.
+- `address public dustRecipient` — Address that receives dust swept from auto-closed deposits.
+- `uint256 public dustThreshold` — Remaining deposit amount below which dust sweep triggers (max 1 USDC).
+- `uint256 public maxIntentsPerDeposit` — Maximum concurrent intents per deposit.
+- `uint256 public intentExpirationPeriod` — Default intent expiration duration.
+- `mapping(address => uint256[]) accountDeposits` — Deposit ids per account.
+- `mapping(uint256 => Deposit) deposits` — Core deposit data:
   - `depositor`, `delegate`, `token`, `intentAmountRange (min,max)`, `acceptingIntents`, `remainingDeposits`, `outstandingIntentAmount`, `intentGuardian`, `retainOnEmpty`.
-- Per‑deposit payment configuration:
+- Per-deposit payment configuration:
   - `depositPaymentMethodData[depositId][paymentMethod]` → `{ intentGatingService, payeeDetails (bytes32), data (bytes) }`
   - `depositPaymentMethods[depositId]` — list of methods; `depositPaymentMethodActive` — active flag; `depositPaymentMethodListed` — ever-listed flag.
   - `depositCurrencies[depositId][paymentMethod]` — list of currency codes (bytes32)
   - `depositCurrencyMinRate[depositId][paymentMethod][currency]` — min conversion rate (1e18)
+- Per-deposit oracle and rate manager configuration:
+  - `depositOracleRateConfig[depositId][paymentMethod][currency]` → `OracleRateConfig`
+  - `depositRateManagerConfig[depositId]` → `RateManagerConfig`
 
 ---
 
@@ -38,22 +48,38 @@ Compared to older versions, Escrow no longer verifies payments directly or manag
 
 `function createDeposit(CreateDepositParams calldata _params)`
 
+`function depositTo(address _depositor, CreateDepositParams calldata _params)` — Third-party funded deposits. Allows anyone to create a deposit on behalf of `_depositor`.
+
 CreateDepositParams
 ```
 struct Range { uint256 min; uint256 max; }
-struct Currency { bytes32 code; uint256 minConversionRate; }
+
+struct OracleRateConfig {
+  address adapter;        // IOracleAdapter address (address(0) = disabled)
+  bytes adapterConfig;    // Adapter-specific config (max 256 bytes)
+  int16 spreadBps;        // Signed spread applied to oracle market rate
+  uint32 maxStaleness;    // Max age of oracle data in seconds
+}
+
+struct Currency {
+  bytes32 code;                   // keccak256(utf8(currencyCode))
+  uint256 minConversionRate;      // Fixed rate floor (1e18 precision)
+  OracleRateConfig oracleRateConfig; // Optional oracle rate config (adapter == address(0) means disabled)
+}
+
 struct DepositPaymentMethodData {
   address intentGatingService;
   bytes32 payeeDetails;   // hashed off-chain identifier
   bytes data;             // optional verifier data (e.g., witness set)
 }
+
 struct CreateDepositParams {
   IERC20 token;
   uint256 amount;
   Range intentAmountRange;
   bytes32[] paymentMethods;                    // e.g., keccak256("venmo")
   DepositPaymentMethodData[] paymentMethodData;// 1:1 with paymentMethods
-  Currency[][] currencies;                     // per method
+  Currency[][] currencies;                     // per method (includes optional oracle config)
   address delegate;                            // optional
   address intentGuardian;                      // optional
   bool retainOnEmpty;                          // keep config when empty
@@ -64,14 +90,15 @@ Notes
 - `paymentMethods` and `currencies` must be whitelisted in `PaymentVerifierRegistry`.
 - `payeeDetails` is bytes32 (do not store raw handles on-chain).
 - All min rates use 1e18 precision.
+- `OracleRateConfig` can be set inline at creation or later via `setOracleRateConfig`.
 
 ---
 
 ## Managing Deposits
 
-- `addFunds(depositId, amount)` — add liquidity (ERC20 must be approved).
-- `removeFunds(depositId, amount)` — may prune expired intents to reclaim liquidity.
-- `withdrawDeposit(depositId)` — returns remaining funds (+expired intent funds), and closes when no outstanding intents.
+- `addFunds(depositId, amount)` — Add liquidity (ERC20 must be approved). Callable by anyone.
+- `removeFunds(depositId, amount)` — May prune expired intents to reclaim liquidity.
+- `withdrawDeposit(depositId)` — Returns remaining funds (+expired intent funds), and closes when no outstanding intents.
 - Payment method management:
   - `addPaymentMethods(depositId, methods, methodData, currencies)`
   - `setPaymentMethodActive(depositId, method, active)`
@@ -84,10 +111,65 @@ Notes
   - `setDelegate(depositId, address)` / `removeDelegate(depositId)`
   - `extendIntentExpiry(depositId, intentHash, newExpiry)` (only `intentGuardian`)
 
+### Oracle Rate Configuration
+
+Depositors can configure oracle-driven rate floors for any currency on their deposit. When configured, the effective rate for a currency is `max(fixedRate, oracleSpreadRate)` — the oracle can only raise the floor, never lower it below the fixed rate.
+
+```
+struct OracleRateConfig {
+  address adapter;        // IOracleAdapter implementation (e.g., ChainlinkOracleAdapter)
+  bytes adapterConfig;    // Feed-specific config (max 256 bytes)
+  int16 spreadBps;        // Signed spread in basis points applied to oracle market rate
+  uint32 maxStaleness;    // Max staleness in seconds
+}
+```
+
+The oracle spread rate is computed as: `oracleRate = marketRate * (10_000 + spreadBps) / 10_000`. Negative spreads are allowed (discount below market). The constraint `(10_000 + spreadBps) > 0` is enforced.
+
+If the oracle returns invalid data or the price is staler than `maxStaleness`, the oracle rate is treated as 0, which means only the fixed rate floor applies. If the fixed rate is also 0, the currency pair is effectively halted.
+
+Management functions:
+- `setOracleRateConfig(depositId, paymentMethod, currencyCode, config)` — Set oracle config for a single currency.
+- `setOracleRateConfigBatch(depositId, paymentMethods[], currencyCodes[][], configs[][])` — Batch set.
+- `removeOracleRateConfig(depositId, paymentMethod, currencyCode)` — Remove oracle config (reverts to fixed rate only).
+- `updateCurrencyConfigBatch(depositId, paymentMethods[], CurrencyRateUpdate[][])` — Batch update fixed rates and/or oracle configs in a single call.
+- `deactivateCurrenciesBatch(depositId, paymentMethods[], currencyCodes[][])` — Batch deactivate currencies.
+
+### Delegated Rate Management
+
+Depositors can delegate rate management to an external `IRateManager` contract (e.g., RateManagerV1). The delegated rate manager can set rates on behalf of the depositor without requiring deposit ownership.
+
+```
+struct RateManagerConfig {
+  address rateManager;    // IRateManager contract address
+  bytes32 rateManagerId;  // Identifier within the rate manager contract
+}
+```
+
+When a rate manager is set, the effective rate becomes: `max(escrowFloor, delegatedRate)` where `escrowFloor = max(fixedRate, oracleSpreadRate)`. The delegated rate can only raise the effective rate above the escrow floor, never lower it. If the rate manager reverts, the escrow floor is used as fallback.
+
+Management functions:
+- `setRateManager(depositId, rateManager, rateManagerId)` — Opt into delegated rate management.
+- `clearRateManager(depositId)` — Remove delegated rate manager.
+
+View functions:
+- `getEffectiveRate(depositId, paymentMethod, currencyCode)` — Returns `max(fixedRate, oracleRate, delegatedRate)`.
+- `getManagerFee(depositId)` — Returns the fee recipient and fee amount from the rate manager. The manager fee is snapshotted at intent signal time and distributed at fulfillment.
+
+### Dust Sweep & Auto-Close
+
+When a deposit's `remainingDeposits` drops to or below `dustThreshold` and there are no outstanding intents:
+- If `retainOnEmpty = false`: the deposit is auto-closed and any remaining dust is swept to `dustRecipient`.
+- If `retainOnEmpty = true`: the deposit config is kept for reuse (e.g., the depositor can add more funds later without reconfiguring payment methods).
+
 ---
 
 ## Orchestrator Integration
 
-- `lockFunds(depositId, intentHash, amount)` — called by Orchestrator on signal.
-- `unlockFunds(depositId, intentHash)` — called on cancel/expire.
-- `unlockAndTransferFunds(depositId, intentHash, transferAmount, to)` — called on fulfillment; returns net amount (after fees) to Orchestrator for onward distribution.
+EscrowV2 uses `OrchestratorRegistry` to authorize callers. Any orchestrator registered in the registry can call these functions:
+
+- `lockFunds(depositId, intentHash, amount)` — Called by Orchestrator on signal.
+- `unlockFunds(depositId, intentHash)` — Called on cancel/expire.
+- `unlockAndTransferFunds(depositId, intentHash, transferAmount, to)` — Called on fulfillment; returns net amount (after fees) to Orchestrator for onward distribution.
+
+Reference: `zkp2p-v2-contracts/contracts/EscrowV2.sol`

--- a/protocol/v3/smart-contracts/orchestrator.md
+++ b/protocol/v3/smart-contracts/orchestrator.md
@@ -4,7 +4,7 @@ title: Orchestrator
 
 ## Overview
 
-The Orchestrator manages the lifecycle of intents and fee distribution. It verifies gating signatures, locks liquidity in Escrow on signal, routes attestation verification to the `UnifiedPaymentVerifier` on fulfillment, and transfers funds net of protocol/referrer fees. It also supports optional post‑intent hooks.
+The Orchestrator (OrchestratorV2) manages the lifecycle of intents and fee distribution. It verifies gating signatures, runs pre-intent hooks, locks liquidity in Escrow on signal, routes attestation verification to the `UnifiedPaymentVerifierV2` on fulfillment, and transfers funds net of protocol/referral/manager fees. It also supports optional post-intent hooks via the V2 hook interface.
 
 ---
 
@@ -13,15 +13,20 @@ The Orchestrator manages the lifecycle of intents and fee distribution. It verif
 - `uint256 internal constant PRECISE_UNIT = 1e18;`
 - `uint256 constant MAX_REFERRER_FEE = 5e16; // 5%`
 - `uint256 constant MAX_PROTOCOL_FEE = 5e16; // 5%`
+- `uint256 constant MAX_MANAGER_FEE = 5e16; // 5%`
 
 ---
 
 ## Key State
 
-- `uint256 immutable chainId` — deployment chain id.
-- `mapping(bytes32 => Intent) intents` — active intents by hash; `mapping(address => bytes32[]) accountIntents` — per-user list.
-- `mapping(bytes32 => uint256) intentMinAtSignal` — snapshot of deposit min amount at signal for partial-release protection.
-- Registries: `EscrowRegistry`, `PaymentVerifierRegistry`, `PostIntentHookRegistry`, `RelayerRegistry`.
+- `uint256 immutable chainId` — Deployment chain id.
+- `mapping(bytes32 => Intent) intents` — Active intents by hash; `mapping(address => bytes32[]) accountIntents` — per-user list.
+- `mapping(bytes32 => uint256) intentMinAtSignal` — Snapshot of deposit min amount at signal time for partial-release protection.
+- `mapping(bytes32 => address) intentManagerFeeRecipient` — Snapshotted manager fee recipient per intent.
+- `mapping(bytes32 => uint256) intentManagerFee` — Snapshotted manager fee per intent.
+- `mapping(address => mapping(uint256 => IPreIntentHook)) depositPreIntentHooks` — Per-deposit generic pre-intent hook (keyed by escrow + depositId).
+- `mapping(address => mapping(uint256 => IPreIntentHook)) depositWhitelistHooks` — Per-deposit whitelist hook (keyed by escrow + depositId).
+- Registries: `EscrowRegistry`, `PaymentVerifierRegistry`, `RelayerRegistry`.
 - Fees: `protocolFee` (1e18), `protocolFeeRecipient`, `allowMultipleIntents` flag, `intentCounter`.
 
 ---
@@ -39,21 +44,32 @@ struct SignalIntentParams {
   address to;                // Recipient of released funds
   bytes32 paymentMethod;     // keccak256("venmo"), etc.
   bytes32 fiatCurrency;      // keccak256("USD"), etc.
-  uint256 conversionRate;    // taker-proposed rate (>= deposit min), 1e18
-  address referrer;          // optional
-  uint256 referrerFee;       // optional (<= MAX_REFERRER_FEE)
+  uint256 conversionRate;    // taker-proposed rate (>= deposit effective rate), 1e18
+  IReferralFee.ReferralFee[] referralFees;  // multi-recipient referral fees
   bytes gatingServiceSignature; // signature from deposit's gating service
-  uint256 signatureExpiration;  // ms/seconds epoch depending on off-chain convention
-  IPostIntentHook postIntentHook; // optional hook
-  bytes data;                // hook data
+  uint256 signatureExpiration;  // epoch timestamp
+  IPostIntentHookV2 postIntentHook; // optional V2 hook
+  bytes preIntentHookData;   // ephemeral data for pre-intent hooks only
+  bytes data;                // persisted in intent, forwarded as signalHookData to post-intent hook
+}
+```
+
+`ReferralFee` struct (from `IReferralFee`):
+```
+struct ReferralFee {
+  address recipient;
+  uint256 fee;   // 1e18 precision, total across all referrals <= MAX_REFERRER_FEE (5%)
 }
 ```
 
 Behavior
-- Validates the deposit and method/currency support via registries.
-- Verifies `gatingServiceSignature` binds `(orchestrator, escrow, depositId, amount, to, paymentMethod, fiatCurrency, conversionRate, expiration, chainId)`.
-- Locks funds on Escrow with `lockFunds(depositId, intentHash, amount)`.
-- Emits `IntentSignaled` with snapshot values.
+1. Validates the deposit and method/currency support via registries.
+2. Executes pre-intent hooks (both generic and whitelist slots) before any state changes. Hooks can only revert to reject.
+3. Verifies `gatingServiceSignature` binds `(orchestrator, escrow, depositId, amount, to, paymentMethod, fiatCurrency, conversionRate, referralFeesHash, expiration, chainId)`.
+4. Snapshots `intentMinAtSignal` from the deposit's min intent amount.
+5. Snapshots manager fee from `EscrowV2.getManagerFee(depositId)` if a rate manager is set.
+6. Locks funds on Escrow with `lockFunds(depositId, intentHash, amount)`.
+7. Emits `IntentSignaled` with snapshot values.
 
 ---
 
@@ -72,18 +88,31 @@ struct FulfillIntentParams {
 ```
 
 Behavior
-- Decodes `paymentProof` and forwards to the `IPaymentVerifier` (UnifiedPaymentVerifier) resolved via the registry/payment method.
+- Decodes `paymentProof` and forwards to the `IPaymentVerifier` (UnifiedPaymentVerifierV2) resolved via the registry/payment method.
 - Requires attestation validity and snapshot match; receives `releaseAmount`.
-- Instructs Escrow to `unlockAndTransferFunds` to Orchestrator, then applies protocol/referrer fees and sends net to `to` (or to the post‑intent hook).
+- Enforces `intentMinAtSignal`: if `releaseAmount < intentMinAtSignal`, the fulfillment reverts. This prevents sub-minimum partial fulfillments.
+- Instructs Escrow to `unlockAndTransferFunds` to Orchestrator, then applies fees in order:
+  1. Protocol fee
+  2. Manager fee (snapshotted at signal time)
+  3. Referral fees (distributed to each recipient)
+  4. Net remainder sent to `to` (or to the post-intent hook if set)
 - Supports partial releases: if the attestation indicates less than the signaled amount, only that portion is released; remaining lock is returned to deposit liquidity.
 
 ---
 
 ## Other Operations
 
-- `cancelIntent(bytes32 intentHash)` — prune and unlock.
-- `releaseFundsToPayer(bytes32 intentHash)` — manual release path for the depositor under configured rules.
-- `pruneIntents(bytes32[] intentIds)` — called by Escrow to prune expired intents.
+- `cancelIntent(bytes32 intentHash)` — Prune and unlock.
+- `releaseFundsToPayer(bytes32 intentHash)` — Manual release path for the depositor under configured rules. Manager fees are also distributed on manual release.
+- `pruneIntents(bytes32[] intentIds)` — Called by Escrow to prune expired intents.
+- `cleanupOrphanedIntents(bytes32[] intentHashes)` — Remove intents that reference deposits no longer in the escrow (e.g., after deposit closure). Callable by anyone.
+
+### Pre-Intent Hook Management
+
+- `setDepositPreIntentHook(escrow, depositId, hook)` — Set the generic pre-intent hook for a deposit. Only callable by depositor or delegate.
+- `setDepositWhitelistHook(escrow, depositId, hook)` — Set the whitelist hook for a deposit. Only callable by depositor or delegate.
+
+Both hooks run during `signalIntent` before state changes. See [Pre-Intent Hooks](./pre-intent-hooks.md) for details.
 
 ---
 
@@ -91,4 +120,11 @@ Behavior
 
 - `IntentSignaled(intentHash, escrow, depositId, paymentMethod, owner, to, amount, fiatCurrency, conversionRate, timestamp)`
 - `IntentFulfilled(intentHash, fundsTransferredTo, amount, isManualRelease)`
+- `IntentPruned(intentHash)`
+- `IntentReferralFeeDistributed(intentHash, feeRecipient, feeAmount)`
+- `IntentManagerFeeSnapshotted(intentHash, feeRecipient, fee)`
+- `DepositPreIntentHookSet(escrow, depositId, hook, setter)`
+- `DepositWhitelistHookSet(escrow, depositId, hook, setter)`
 - `ProtocolFeeUpdated(protocolFee)` / `ProtocolFeeRecipientUpdated(addr)`
+
+Reference: `zkp2p-v2-contracts/contracts/OrchestratorV2.sol`

--- a/protocol/v3/smart-contracts/post-intent-hooks.md
+++ b/protocol/v3/smart-contracts/post-intent-hooks.md
@@ -1,93 +1,101 @@
 ---
-title: Post‑Intent Hooks
+title: Post-Intent Hooks
 ---
 
 ## Overview
 
-Post‑intent hooks let integrators run custom logic immediately after an intent is fulfilled, before funds are delivered to the end recipient. Typical uses include split payouts, on‑chain actions (stake, swap), builder/affiliate fees, or protocol‑specific settlement flows.
+Post-intent hooks let integrators run custom logic immediately after an intent is fulfilled, before funds are delivered to the end recipient. Typical uses include split payouts, on-chain actions (stake, swap), builder/affiliate fees, cross-chain bridging, or protocol-specific settlement flows.
 
-Hooks are optional. If a hook is set on an intent, the Orchestrator will approve the hook to pull the entire net amount (after protocol/referrer fees) and then call the hook. The hook must pull exactly that amount from the Orchestrator and route it as desired. If no hook is set, funds are sent directly to `intent.to`.
+Hooks are optional. If a hook is set on an intent, the Orchestrator will approve the hook to pull the executable amount (after protocol/manager/referral fees) and then call the hook. The hook must pull exactly that amount from the Orchestrator and route it as desired. If no hook is set, funds are sent directly to `intent.to`.
 
 ---
 
-## Interface
+## Interface (V2)
 
-```
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import { IOrchestrator } from "./IOrchestrator.sol";
+interface IPostIntentHookV2 {
+    struct HookIntentContext {
+        address owner;
+        address to;
+        address escrow;
+        uint256 depositId;
+        uint256 amount;
+        uint256 timestamp;
+        bytes32 paymentMethod;
+        bytes32 fiatCurrency;
+        uint256 conversionRate;
+        bytes32 payeeId;
+        bytes signalHookData;   // data from SignalIntentParams.data
+    }
 
-/**
- * @title IPostIntentHook
- * @notice Interface for post-intent hooks
- */
-interface IPostIntentHook {
-    /**
-     * @notice Post-intent hook
-     * @param _intent The intent data structure containing all intent information
-     * @param _fulfillIntentData The data passed to fulfillIntent
-     */
+    struct HookExecutionContext {
+        bytes32 intentHash;
+        address token;              // deposit token address
+        uint256 executableAmount;   // amount available after all fees
+        HookIntentContext intent;
+    }
+
     function execute(
-        IOrchestrator.Intent memory _intent,
-        uint256 _amountNetFees,
-        bytes calldata _fulfillIntentData
+        HookExecutionContext calldata _ctx,
+        bytes calldata _fulfillHookData
     ) external;
 }
 ```
 
-Source: `zkp2p-v2-contracts/contracts/interfaces/IPostIntentHook.sol`.
+Source: `zkp2p-v2-contracts/contracts/interfaces/IPostIntentHookV2.sol`
+
+:::note
+The V1 `IPostIntentHook` interface (which took `Intent memory`, `uint256 _amountNetFees`, `bytes calldata`) is used only by the legacy Orchestrator. V3 uses `IPostIntentHookV2` exclusively. The `PostIntentHookRegistry` is also legacy-only; V3 hooks are set per-intent at signal time.
+:::
 
 ---
 
 ## Execution Model
 
-- On successful `fulfillIntent`, the Orchestrator:
-  - Calculates protocol and referrer fees, subtracts them from `releaseAmount` to get `_amountNetFees`.
-  - Approves the hook for exactly `_amountNetFees` of the deposit token.
-  - Calls `hook.execute(intent, _amountNetFees, postIntentHookData)`.
-  - After execution, checks that the hook pulled exactly `_amountNetFees` and that the Orchestrator’s token balance did not increase; then it resets allowance to 0.
-- If any check fails or the hook reverts, the entire fulfillment reverts and no state changes persist.
+On successful `fulfillIntent`, the OrchestratorV2:
+1. Calculates and distributes protocol, manager, and referral fees from `releaseAmount` to get `executableAmount`.
+2. Sets allowance for the hook to pull exactly `executableAmount` of the deposit token.
+3. Calls `hook.execute(HookExecutionContext, fulfillHookData)`.
+4. After execution, checks that the hook pulled exactly `executableAmount` and that the Orchestrator's token balance did not increase; then resets allowance to 0.
+
+If any check fails or the hook reverts, the entire fulfillment reverts and no state changes persist.
 
 Invariants enforced by Orchestrator:
-- Hook must pull exactly `_amountNetFees` via `transferFrom(orchestrator, …)`.
+- Hook must pull exactly `executableAmount` via `transferFrom(orchestrator, …)`.
 - Hook must not push tokens back to the Orchestrator.
 - Allowance is zeroed after execution.
 
 ---
 
+## Reading Context
+
+`HookExecutionContext` provides everything hooks typically need:
+- `intentHash` — The unique intent identifier.
+- `token` — The deposit token address (no need to query Escrow).
+- `executableAmount` — Exact amount the hook must pull.
+- `intent` — Full intent context including `signalHookData` (set at signal time via `SignalIntentParams.data`).
+
+---
+
 ## Supplying Hook Data
 
-- `intent.data` (bytes): set at `signalIntent` for static configuration (e.g., split recipients, target address).
-- `postIntentHookData` (bytes): supplied at `fulfillIntent` for dynamic inputs (e.g., memo, execution flags).
+- `SignalIntentParams.data` → Persisted in the intent as `intent.data`, forwarded as `HookIntentContext.signalHookData`. Use for static configuration (e.g., split recipients, target address, bridge destination chain).
+- `FulfillIntentParams.postIntentHookData` → Passed as `_fulfillHookData` at fulfillment time. Use for dynamic inputs (e.g., memo, execution flags, bridge quote).
 
 Both are forwarded to the hook; use either or both depending on your design.
 
 ---
 
-## Access Control and Whitelisting
+## Built-in Hooks
 
-- Hooks must be whitelisted in `PostIntentHookRegistry`; otherwise `signalIntent` reverts with `PostIntentHookNotWhitelisted`.
-- Recommended pattern in hooks: `require(msg.sender == expectedOrchestrator)` to ensure only the Orchestrator can trigger execution.
+### AcrossBridgeHookV2
 
-Relevant addresses (Base mainnet): see Protocol V3 → Deployments for `PostIntentHookRegistry` and `Orchestrator` addresses.
+Bridges released funds to another chain via the Across protocol. The hook pulls funds from the Orchestrator and deposits them into the Across SpokePool.
 
----
-
-## Reading Context
-
-`IOrchestrator.Intent` includes:
-- `owner`, `to`, `escrow`, `depositId`, `amount`, `timestamp`
-- `paymentMethod`, `fiatCurrency`, `conversionRate`, `payeeId`
-- `referrer`, `referrerFee`, `postIntentHook`, `data`
-
-To discover the token:
-
-```
-import { IEscrow } from "zkp2p-v2-contracts/contracts/interfaces/IEscrow.sol";
-IEscrow.Deposit memory dep = IEscrow(_intent.escrow).getDeposit(_intent.depositId);
-IERC20 token = dep.token;
-```
+Address: `0xCcC9163451DE31a625D48e417e0fD1a329c7f7cf` (Base mainnet)
 
 ---
 
@@ -95,54 +103,53 @@ IERC20 token = dep.token;
 
 1) Forward payout to a target
 
-```
-contract ForwardHook is IPostIntentHook {
-  IERC20 public immutable token;
+```solidity
+contract ForwardHookV2 is IPostIntentHookV2 {
   address public immutable orchestrator;
-  constructor(address _token, address _orchestrator){ token = IERC20(_token); orchestrator = _orchestrator; }
+  constructor(address _orchestrator) { orchestrator = _orchestrator; }
 
-  function execute(IOrchestrator.Intent memory intent, uint256 amount, bytes calldata) external override {
+  function execute(HookExecutionContext calldata ctx, bytes calldata) external override {
     require(msg.sender == orchestrator, "only orchestrator");
-    address target = abi.decode(intent.data, (address));
+    address target = abi.decode(ctx.intent.signalHookData, (address));
     require(target != address(0), "target=0");
-    token.transferFrom(msg.sender, target, amount);
+    IERC20(ctx.token).transferFrom(msg.sender, target, ctx.executableAmount);
   }
 }
 ```
 
 2) Split payout (e.g., 95% to `intent.to`, 5% to builder)
 
-```
-contract SplitHook is IPostIntentHook {
-  IERC20 public immutable token; address public immutable orchestrator; address public immutable builder;
-  constructor(address _token, address _orchestrator, address _builder){ token = IERC20(_token); orchestrator=_orchestrator; builder=_builder; }
-  function execute(IOrchestrator.Intent memory intent, uint256 amount, bytes calldata) external override {
+```solidity
+contract SplitHookV2 is IPostIntentHookV2 {
+  address public immutable orchestrator;
+  address public immutable builder;
+  constructor(address _orchestrator, address _builder) { orchestrator = _orchestrator; builder = _builder; }
+
+  function execute(HookExecutionContext calldata ctx, bytes calldata) external override {
     require(msg.sender == orchestrator, "only orchestrator");
-    uint256 fee = amount * 5 / 100; uint256 toAmt = amount - fee;
-    token.transferFrom(msg.sender, intent.to, toAmt);
-    token.transferFrom(msg.sender, builder, fee);
+    uint256 fee = ctx.executableAmount * 5 / 100;
+    uint256 toAmt = ctx.executableAmount - fee;
+    IERC20(ctx.token).transferFrom(msg.sender, ctx.intent.to, toAmt);
+    IERC20(ctx.token).transferFrom(msg.sender, builder, fee);
   }
 }
 ```
 
 3) What will revert
-- Pulling only part of `amount` (e.g., half) → Orchestrator checks and reverts.
-- Sending any tokens to the Orchestrator during execution → balance‑increase check reverts.
-- Unwhitelisted hook → cannot be set on intent.
-
-See `zkp2p-v2-contracts/contracts/mocks/*PostIntentHook*.sol` for more patterns (partial pull, push, reentrancy tests).
+- Pulling only part of `executableAmount` → Orchestrator checks and reverts.
+- Sending any tokens to the Orchestrator during execution → balance-increase check reverts.
 
 ---
 
 ## Integration Steps
 
-- Deploy your hook with the expected Orchestrator (and token if using a fixed token pattern).
-- Ask governance to whitelist it in `PostIntentHookRegistry`.
-- When signaling an intent, set `postIntentHook` and encode any static inputs in `data`.
-- When fulfilling, pass any dynamic `postIntentHookData` as needed.
+1. Implement `IPostIntentHookV2` with the structured `HookExecutionContext`.
+2. Deploy your hook. Note the Orchestrator address for access control.
+3. When signaling an intent, set `postIntentHook` to your hook address and encode any static inputs in `data`.
+4. When fulfilling, pass any dynamic `postIntentHookData` as needed.
 
 Security tips
 - Keep execution deterministic and short; long external calls may waste gas or revert fulfillments.
 - Do not rely on reentrancy into Orchestrator; it uses `ReentrancyGuard` in `fulfillIntent`.
-- Always pull exactly the approved `amount` from the Orchestrator and handle tokens that may return `false`—use OpenZeppelin `SafeERC20` if needed.
-
+- Always pull exactly the approved `executableAmount` from the Orchestrator and handle tokens that may return `false` — use OpenZeppelin `SafeERC20` if needed.
+- The hook receives the token address in `ctx.token`, so it does not need to query the Escrow.

--- a/protocol/v3/smart-contracts/pre-intent-hooks.md
+++ b/protocol/v3/smart-contracts/pre-intent-hooks.md
@@ -1,0 +1,102 @@
+---
+title: Pre-Intent Hooks
+---
+
+## Overview
+
+Pre-intent hooks run during `signalIntent` on OrchestratorV2, **before** any state changes (fund locking, intent creation). They provide deposit-level access control — a hook can only revert to reject an incoming intent. If the hook does not revert, the intent proceeds normally.
+
+Each deposit has **two dedicated hook slots** on OrchestratorV2:
+1. **Generic pre-intent hook** — General-purpose validation (e.g., signature gating).
+2. **Whitelist hook** — Address-based access control (e.g., private orderbook).
+
+Both hooks run sequentially. If either reverts, the entire `signalIntent` call reverts.
+
+---
+
+## Interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { IReferralFee } from "./IReferralFee.sol";
+
+interface IPreIntentHook {
+    struct PreIntentContext {
+        address taker;
+        address escrow;
+        uint256 depositId;
+        uint256 amount;
+        address to;
+        bytes32 paymentMethod;
+        bytes32 fiatCurrency;
+        uint256 conversionRate;
+        IReferralFee.ReferralFee[] referralFees;
+        bytes preIntentHookData;  // ephemeral data from SignalIntentParams.preIntentHookData
+    }
+
+    /// @notice Called by the Orchestrator during signalIntent before state changes.
+    /// @dev Revert to reject the incoming intent.
+    function validateSignalIntent(PreIntentContext calldata _ctx) external;
+}
+```
+
+Source: `zkp2p-v2-contracts/contracts/interfaces/IPreIntentHook.sol`
+
+---
+
+## Built-in Implementations
+
+### SignatureGatingPreIntentHook
+
+EIP-191 signature validation per deposit. A configurable signer must produce a valid signature over the intent parameters for the intent to proceed.
+
+The signed message binds: `orchestrator`, `escrow`, `depositId`, `amount`, `taker`, `to`, `paymentMethod`, `fiatCurrency`, `conversionRate`, `keccak256(abi.encode(referralFees))`, `expiration`, `chainId`.
+
+**Setup:**
+1. Set the hook: `orchestrator.setDepositPreIntentHook(escrow, depositId, signatureGatingHookAddress)`
+2. Configure the signer: `signatureGatingHook.setDepositSigner(escrow, depositId, signerAddress)`
+
+**Usage:** The taker passes the signature and expiration in `SignalIntentParams.preIntentHookData` (ABI-encoded).
+
+Address: `0x62D410a3d6FC766dd2192be2a67a5fc79c5c2e1F` (Base mainnet)
+
+Source: `zkp2p-v2-contracts/contracts/hooks/SignatureGatingPreIntentHook.sol`
+
+### WhitelistPreIntentHook
+
+Address whitelist per deposit and payment method. Only whitelisted taker addresses can signal intents on the deposit for a given payment method. Enables private orderbook patterns.
+
+**Setup:**
+1. Set the hook: `orchestrator.setDepositWhitelistHook(escrow, depositId, whitelistHookAddress)`
+2. Add addresses: `whitelistHook.addToWhitelist(escrow, depositId, paymentMethod, addresses[])`
+
+**Management:**
+- `removeFromWhitelist(escrow, depositId, paymentMethod, addresses[])` — Remove addresses.
+- `isWhitelisted(escrow, depositId, paymentMethod, taker)` — Check if an address is whitelisted.
+
+Address: `0xd793369b11357cdd076A9c631F6c44ff8e6353eA` (Base mainnet)
+
+Source: `zkp2p-v2-contracts/contracts/hooks/WhitelistPreIntentHook.sol`
+
+---
+
+## Access Control
+
+- Only the depositor or their delegate can set hooks on a deposit via `orchestrator.setDepositPreIntentHook(...)` or `orchestrator.setDepositWhitelistHook(...)`.
+- Setting a hook to `address(0)` disables it.
+- Hooks are set per (escrow, depositId) pair and apply to all intents on that deposit.
+
+---
+
+## Writing a Custom Pre-Intent Hook
+
+1. Implement `IPreIntentHook.validateSignalIntent(PreIntentContext calldata _ctx)`.
+2. Revert with a descriptive error to reject intents. Return normally to approve.
+3. The hook receives the full intent context including `preIntentHookData` for custom validation logic.
+4. Deploy and have the depositor set it via `setDepositPreIntentHook` or `setDepositWhitelistHook`.
+
+:::note
+Pre-intent hooks are **view-like** in intent — they should only validate, not modify state. However, the interface does not enforce `view` to allow hooks that read external state.
+:::

--- a/protocol/v3/smart-contracts/unified-payment-verifier.md
+++ b/protocol/v3/smart-contracts/unified-payment-verifier.md
@@ -4,7 +4,11 @@ title: Unified Payment Verifier
 
 ## Overview
 
-`UnifiedPaymentVerifier` verifies standardized off‑chain attestations produced by the Attestation Service. It validates EIP‑712 signatures via a pluggable `AttestationVerifier`, enforces snapshot consistency with on‑chain intent state, prevents replay via nullifiers, and caps the release amount to the signaled intent amount.
+`UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` on Base) is the production verifier for V3 contracts. It verifies standardized off‑chain attestations produced by the Attestation Service. It validates EIP‑712 signatures via a pluggable `AttestationVerifier`, enforces snapshot consistency with on‑chain intent state, prevents replay via nullifiers, and caps the release amount to the signaled intent amount.
+
+:::note
+The legacy `UnifiedPaymentVerifier` (`0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163`) is used only by the deprecated V3 Orchestrator. New intents use `UnifiedPaymentVerifierV2` exclusively.
+:::
 
 ---
 

--- a/protocol/zkp2p-protocol.md
+++ b/protocol/zkp2p-protocol.md
@@ -13,15 +13,11 @@ The ZKP2P Protocol enables permissionless and fully noncustodial buying and sell
 
 With ZKP2P V1, we launched the first ever trust minimized fiat to crypto on/offramp in production, enabling swaps between USD in Venmo, EUR in Revolut and INR in HDFC Bank for USDC. These swaps were powered by ZK proofs using the [zkEmail](https://prove.email/) library. V1 intended to be an alpha proof of concept which explored and pushed the edge of what could be done by bringing valuable web2 data for use onchain in a privacy preserving and verifiable way, while solving the biggest pain point that exists in crypto.
 
-With the current ZKP2P protocol, we are a doubling down of this vision to create a protocol that enables fast, cheap, low fraud and DeFi composable actions between offchain and onchain assets. V2 extends upon V1 and solves many of its limitations including:
-
-1. Complex user flows
-2. Fragmentation of liquidity
-3. Difficulty for external integrations directly at the protocol layer
-4. No optional identity verification layer to unlock higher limits
-5. Proving speed
-
 ## The V2 Protocol
+
+:::note
+V2 is now legacy. The V2 contracts are deployed on Sepolia testnet only and are no longer receiving updates. See the V3 Protocol section below for the current production system.
+:::
 
 The ZKP2P V2 protocol was designed from the ground up to make it more generic, capital efficient and composable. The protocol now supports the following:
 1. Generic to any payment platform and fiat currency as long as the platform uses a server to server API to generate proofs
@@ -33,17 +29,21 @@ The ZKP2P V2 protocol was designed from the ground up to make it more generic, c
 
 Below is an illustrative example of the V2 protoclol flow using TLSNotary as the cryptographic primitive.
 
-![Protocol Overview](/img/developer/ZKP2PProtocolOverview.jpeg)  
+![Protocol Overview](/img/developer/ZKP2PProtocolOverview.jpeg)
 
 # The V3 Protocol
 
-ZKP2P V3 enables permissionless, non‑custodial exchange between off‑chain payments and on‑chain tokens with faster attestations, a simpler on‑chain surface, and clearer integration points. It builds on V2 with an off‑chain Attestation Service and a unified on‑chain verifier, while keeping funds trustless in Escrow smart contracts.
+ZKP2P V3 is the current production protocol deployed on Base mainnet. It enables permissionless, non‑custodial exchange between off‑chain payments and on‑chain tokens with faster attestations, a simpler on‑chain surface, and clearer integration points.
 
 At a Glance
 - Off‑chain attestation: proofs (e.g., Reclaim/TLSNotary) are validated off‑chain and returned as an EIP‑712 PaymentAttestation.
-- Unified on‑chain verification: a single `UnifiedPaymentVerifier` checks the attestation and enforces protocol rules (snapshot match, nullifiers, capping).
-- Orchestrated intents: `Orchestrator` owns the intent lifecycle (signal, cancel, fulfill) and fee routing; `Escrow` focuses on deposits and token custody.
-- Typed methods: payment “methods” are bytes32 identifiers (e.g., keccak256("venmo")) resolved through a registry, decoupling on‑chain logic from provider addresses.
+- Unified on‑chain verification: a single `UnifiedPaymentVerifierV2` checks the attestation and enforces protocol rules (snapshot match, nullifiers, capping).
+- Orchestrated intents: `OrchestratorV2` owns the intent lifecycle (signal, cancel, fulfill) and fee routing; `EscrowV2` focuses on deposits and token custody.
+- Oracle rate management: depositors can configure oracle adapters (Chainlink) per currency to auto-adjust minimum conversion rates based on market prices.
+- Delegated rate management: depositors can opt into external rate managers (RateManagerV1) that set rates on their behalf with fee sharing.
+- Pre-intent hooks: on-chain deposit-level access control (signature gating, address whitelists) that runs before fund locking.
+- Multi-orchestrator support: `OrchestratorRegistry` authorizes multiple orchestrator contracts on EscrowV2.
+- Typed methods: payment "methods" are bytes32 identifiers (e.g., keccak256("venmo")) resolved through a registry, decoupling on‑chain logic from provider addresses.
 - Cleaner APIs: gating/signing includes method, fiat, conversion rate, and addresses; quotes expose richer filters and deposit stats.
 
 
@@ -53,14 +53,14 @@ At a Glance
 **Perform Off-chain Payment.** Execute an offchain payment in fiat currency through the payment service to the designated seller
 
 **Proof of Payment:** After payment, the buyer generates a proof of payment data and it's authenticity along with also extracting the following from the payment data:
-- Off-ramper’s Off-chain payment ID
+- Off-ramper's Off-chain payment ID
 - Payment amount
 - Payment timestamp
 - Payment currency
 - Other optional state (e.g. transaction status) to be handled by the Verifier
 
 **Unlocking Escrow.** The smart contract checks the proof of payment along with the following to unlock the escrowed funds:
-- Verification of the on-ramper’s intent
+- Verification of the on-ramper's intent
 - Correspondence of the deposit to the correct off-ramper
 - Adequacy of the payment amount
 - Timing of the payment post-intent

--- a/protocol/zkp2p-protocol.md
+++ b/protocol/zkp2p-protocol.md
@@ -16,7 +16,7 @@ With ZKP2P V1, we launched the first ever trust minimized fiat to crypto on/offr
 ## The V2 Protocol
 
 :::note
-V2 is now legacy. The V2 contracts are deployed on Sepolia testnet only and are no longer receiving updates. See the V3 Protocol section below for the current production system.
+V2 is now legacy. The V2 contracts remain deployed on Base mainnet but are no longer receiving updates. See the V3 Protocol section below for the current production system.
 :::
 
 The ZKP2P V2 protocol was designed from the ground up to make it more generic, capital efficient and composable. The protocol now supports the following:


### PR DESCRIPTION
## Summary

- Full rewrite of deployments page with V3 core/registries/hooks/oracles/legacy contract tables and 3 new payment methods (alipay, chime, luxon)
- New pre-intent hooks page documenting IPreIntentHook, SignatureGatingPreIntentHook, WhitelistPreIntentHook
- Major updates to escrow and orchestrator docs: oracle rate config, delegated rate management, dust sweep, multi-referral fees, manager fees, OrchestratorRegistry
- Rewrote post-intent hooks for IPostIntentHookV2 with HookExecutionContext
- Added OrchestratorRegistry, RateManagerV1, ChainlinkOracleAdapter to smart contracts overview
- Updated migration guide with V3 Contract Upgrade section
- Updated verifier references to UnifiedPaymentVerifierV2
- V2 deprecation note, V3 as current production in protocol overview
- Removed all Sepolia references; corrected V2 deployment to Base mainnet
- Sidebar updated with pre-intent-hooks entry

## Test plan

- [x] `yarn build` passes with no broken links or warnings
- [x] `yarn serve` — all pages load, sidebar renders correctly
- [ ] Spot-check contract addresses against `zkp2p-v2-contracts/deployments/base/*.json`
- [ ] Spot-check payment method currencies against latest snapshots