### PR TITLE
docs: bump SDK version to v0.3.0 and clarify createDeposit paths

### DIFF
--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -141,7 +141,7 @@ Supported payment platforms and keys:
 | Luxon | `luxon` |
 | N26 | `n26` |
 
-Each item in `depositData` must line up by index with `processorNames`. If you pass `payeeDetailsHashes` to `createDeposit()`, the SDK uses those hashes directly and no API key is needed. If you do not have hashes yet, call `registerPayeeDetails()` first with an `apiKey` or `authorizationToken`, then pass the returned hashes to `createDeposit()`.
+Each item in `depositData` must line up by index with `processorNames`. If you pass `payeeDetailsHashes` to `createDeposit()`, the SDK uses those hashes directly and skips the curator call. Otherwise the SDK forwards each `depositData` object to curator's public `/v1/makers/create` endpoint to obtain the hashes, so the key names need to match the processor exactly. Either path works without an API key — you can also call `registerPayeeDetails()` standalone to get the hashes ahead of time.
 
 The expected `depositData` shape for each platform is:
 

--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -141,7 +141,7 @@ Supported payment platforms and keys:
 | Luxon | `luxon` |
 | N26 | `n26` |
 
-Each item in `depositData` must line up by index with `processorNames`. The SDK forwards those objects directly to curator's `/v1/makers/create` endpoint, so the key names need to match the processor exactly.
+Each item in `depositData` must line up by index with `processorNames`. If you pass `payeeDetailsHashes` to `createDeposit()`, the SDK uses those hashes directly and no API key is needed. If you do not have hashes yet, call `registerPayeeDetails()` first with an `apiKey` or `authorizationToken`, then pass the returned hashes to `createDeposit()`.
 
 The expected `depositData` shape for each platform is:
 

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -25,7 +25,7 @@ Create a client with `new Zkp2pClient(opts)`.
 | `runtimeEnv` | No | Runtime environment: `production`, `preproduction`, or `staging`. Defaults to `production` |
 | `indexerUrl` | No | Override for the indexer GraphQL endpoint |
 | `baseApiUrl` | No | Override for ZKP2P service APIs |
-| `apiKey` | No | Optional curator API key — required for `registerPayeeDetails()`. When provided, it also enriches responses for other methods (e.g. `getQuote` returns maker `depositData`) |
+| `apiKey` | No | Optional curator API key — not required for any method. When provided, some responses are enriched (e.g. `getQuote` returns maker `depositData`) |
 | `authorizationToken` | No | Optional bearer token for hybrid authentication |
 | `getAuthorizationToken` | No | Async token provider for long-lived clients |
 | `indexerApiKey` | No | Optional `x-api-key` header for indexer proxy authentication |
@@ -40,8 +40,8 @@ const client = new Zkp2pClient({
 });
 ```
 
-:::info API key usage
-`registerPayeeDetails()` requires `apiKey` or `authorizationToken`. All other SDK methods work without auth credentials; when provided, they enrich responses. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
+:::info No API key required
+All SDK methods work without `apiKey` or `authorizationToken`. Auth credentials are optional and only affect response richness. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
 :::
 
 ## Prepared transactions

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -25,7 +25,7 @@ Create a client with `new Zkp2pClient(opts)`.
 | `runtimeEnv` | No | Runtime environment: `production`, `preproduction`, or `staging`. Defaults to `production` |
 | `indexerUrl` | No | Override for the indexer GraphQL endpoint |
 | `baseApiUrl` | No | Override for ZKP2P service APIs |
-| `apiKey` | No | Optional curator API key — not required for any method. When provided, some responses are enriched (e.g. `getQuote` returns maker `depositData`) |
+| `apiKey` | No | Optional curator API key — required for `registerPayeeDetails()`. When provided, it also enriches responses for other methods (e.g. `getQuote` returns maker `depositData`) |
 | `authorizationToken` | No | Optional bearer token for hybrid authentication |
 | `getAuthorizationToken` | No | Async token provider for long-lived clients |
 | `indexerApiKey` | No | Optional `x-api-key` header for indexer proxy authentication |
@@ -40,8 +40,8 @@ const client = new Zkp2pClient({
 });
 ```
 
-:::info No API key required
-All SDK methods work without `apiKey` or `authorizationToken`. Auth credentials are optional and only affect response richness. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
+:::info API key usage
+`registerPayeeDetails()` requires `apiKey` or `authorizationToken`. All other SDK methods work without auth credentials; when provided, they enrich responses. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
 :::
 
 ## Prepared transactions

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -8,7 +8,7 @@ slug: /sdk
 
 ## What this does
 
-`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, and embed the Peer extension onramp. The current npm release is `0.2.3` and is published under the MIT license.
+`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, and embed the Peer extension onramp. The current npm release is `0.3.0` and is published under the MIT license.
 
 ## Who is this for?
 


### PR DESCRIPTION
## Summary

- Bump hardcoded SDK version from \`0.2.3\` to \`0.3.0\` in `developer/sdk/overview.md`.
- Rewrite the `developer/offramp-integration.md` paragraph to describe both `createDeposit()` paths accurately: pass `payeeDetailsHashes` to skip the curator call, or let the SDK forward `depositData` to curator's public `/v1/makers/create` endpoint. Mentions `registerPayeeDetails()` as the standalone option.

## Why

SDK v0.3.0 shipped today, so the hardcoded version reference is stale. The offramp note also predated the `payeeDetailsHashes` shortcut and didn't mention `registerPayeeDetails()` at all.

## Verified against source

- `packages/sdk/src/adapters/api.ts:248-264` — \`apiPostDepositDetails\` explicitly drops auth params: \"Curator does not require auth for /v1/makers/create.\"
- \`packages/sdk/src/client/Zkp2pClient.ts:1922-1956\` — \`registerPayeeDetails\` calls the adapter without any auth.
- \`packages/sdk/src/client/Zkp2pClient.ts:123-127\` — \`apiKey\` JSDoc: \"Not used by registerPayeeDetails or getTakerTier.\"
- \`curator/src/api/v1/maker/makerRouter.ts:16-62\` — \`/v1/makers/create\` is registered under \"PUBLIC ENDPOINTS (no auth required, rate limited)\" with \`publicMakerRateLimiter\`.

## Test plan

Not run — text-only changes to two markdown files with no build/code impact.