### PR TITLE
docs: add PayPal seller registration details to liquidity guide

### DIFF
--- a/guides/for-sellers/provide-liquidity-sell-usdc.md
+++ b/guides/for-sellers/provide-liquidity-sell-usdc.md
@@ -94,8 +94,13 @@ Enter your username/account details for the selected platform:
 - Revolut Revtag  
 - Wise Wisetag  
 - Mercado Pago CVU  
+- PayPal Email  
 
 > 🔍 **Double-check accuracy** — these details are how buyers send you money.
+
+:::info PeerAuth Extension Required for PayPal
+PayPal requires identity verification through the PeerAuth browser extension (v0.4.13+). When you select PayPal, you will be prompted to complete extension-based verification before your deposit goes live. This is the same flow used for Wise.
+:::
 
 ![Provide Step 10](/img/provide-liquidity/ProvideStep9.png)
 


### PR DESCRIPTION
## Summary
- Adds PayPal Email to the payee details list in Step 10 of the seller liquidity guide
- Adds admonition noting PeerAuth extension verification requirement for PayPal (same as Wise, requires v0.4.13+)

Closes #45

## Context
PayPal maker registration shipped in zkp2p-clients PRs #610 and #615 (merged April 15-17). The seller guide listed PayPal in Step 9 but omitted it from Step 10 payee details and had no mention of the extension verification requirement.

## Test plan
- [x] `yarn build` passes with no broken links or warnings
- [x] Single file change, no scope creep