### PR TITLE
Add PayPal payee details and PeerAuth verification note

### DIFF
--- a/guides/for-sellers/provide-liquidity-sell-usdc.md
+++ b/guides/for-sellers/provide-liquidity-sell-usdc.md
@@ -94,8 +94,13 @@ Enter your username/account details for the selected platform:
 - Revolut Revtag  
 - Wise Wisetag  
 - Mercado Pago CVU  
+- PayPal Email
 
 > 🔍 **Double-check accuracy** — these details are how buyers send you money.
+
+:::info PayPal & Wise Extension Verification
+PayPal and Wise require account verification through the PeerAuth browser extension (v0.4.13+). After entering your payee details, follow the extension prompt to complete verification before your deposit goes live.
+:::
 
 ![Provide Step 10](/img/provide-liquidity/ProvideStep9.png)
 


### PR DESCRIPTION
## Summary

- Adds PayPal Email to the list of platform-specific payee identifiers in Step 10
- Adds an info admonition noting that PayPal and Wise require PeerAuth extension (v0.4.13+) verification before deposits go live

## Why

Sellers setting up PayPal deposits need to know what identifier to enter and that PeerAuth verification is required before their deposit becomes active.

Closes #45

## Changes

- `guides/for-sellers/provide-liquidity-sell-usdc.md`: Added PayPal Email to payee list, added :::info admonition for PeerAuth extension verification requirement

## Test plan

Not run (docs-only change, build gate not executed in this context)