### PR TITLE
docs: add chargeback protection guide for sellers

### DIFF
--- a/guides-sidebars.js
+++ b/guides-sidebars.js
@@ -27,6 +27,7 @@ module.exports = {
         'for-sellers/update-usdc-rates',
         'for-sellers/calculating-apr',
         'for-sellers/manual-releases',
+        'for-sellers/chargeback-protection',
         {
           type: 'category',
           label: 'Automated Rate Management (ARM)',

--- a/guides/for-sellers/chargeback-protection.md
+++ b/guides/for-sellers/chargeback-protection.md
@@ -5,9 +5,15 @@ title: Chargeback Protection
 
 # Chargeback Protection
 
-Chargeback Protection limits who can fill your deposit. When it is enabled, only orders routed through Peer's Pay signal relayer can fill your deposit.
+### What is Chargeback Protection
 
-This means every order that reaches your deposit has already been validated before it gets to you. For payment methods like PayPal and Cash App, that lowers the risk of a buyer payment turning into a chargeback dispute later.
+Chargeback Protection limits who can fill your deposit. When it is enabled, only orders routed through Peer's Pay signal relayer can fill it.
+
+That means every order that fills your deposit has already been pre-validated before it reaches you. For payment methods like PayPal and Cash App, that lowers the risk of a buyer payment turning into a chargeback dispute later.
+
+:::info Who is this for?
+This guide is for sellers who want fewer chargeback disputes on higher-risk payment platforms.
+:::
 
 ### Who Can Enable It
 
@@ -18,18 +24,18 @@ You can enable Chargeback Protection if you are:
 
 ### How to Enable It
 
-1. Open the details page for the deposit you want to protect.
+1. Open your deposit details.
 2. Find the **Chargeback Protection** toggle in the deposit controls section.
-3. Turn the toggle on.
+3. Flip the toggle on.
 4. Confirm both wallet prompts to finish setup.
 
 :::info Expect two wallet prompts
-Turning on Chargeback Protection sends two on-chain transactions. The first turns on protection for the deposit, and the second authorizes Peer's Pay relayer to fill it. Both transactions must complete before the deposit becomes protected.
+Turning on Chargeback Protection sends two on-chain transactions. One sets up protection for the deposit, and the other whitelists Peer's Pay signal relayer. Both transactions must complete before the deposit becomes protected.
 :::
 
 ### What the Protected Badge Means
 
-After Chargeback Protection is enabled, a **Protected** badge appears:
+After Chargeback Protection is enabled, a **Protected** badge appears in three places:
 
 - In the deposit list
 - In the deposit header
@@ -50,6 +56,6 @@ Chargeback Protection is less important for platforms like Revolut, Wise, and Mo
 
 ### Trade-offs
 
-Chargeback Protection improves safety, but it can reduce how many buyers are able to fill your deposit. Only orders routed through Pay can take the deposit, so fills may be slower.
+Chargeback Protection improves safety, but it can reduce how many buyers are able to fill your deposit. Only orders routed through Pay can take the deposit, so you may see fewer potential takers.
 
 If you care more about safety than speed, turn it on. If you care more about getting filled as quickly as possible, you may prefer to leave it off.

--- a/guides/for-sellers/chargeback-protection.md
+++ b/guides/for-sellers/chargeback-protection.md
@@ -1,0 +1,55 @@
+---
+id: chargeback-protection
+title: Chargeback Protection
+---
+
+# Chargeback Protection
+
+Chargeback Protection limits who can fill your deposit. When it is enabled, only orders routed through Peer's Pay signal relayer can fill your deposit.
+
+This means every order that reaches your deposit has already been validated before it gets to you. For payment methods like PayPal and Cash App, that lowers the risk of a buyer payment turning into a chargeback dispute later.
+
+### Who Can Enable It
+
+You can enable Chargeback Protection if you are:
+
+- The deposit owner
+- A vault delegate managing the deposit on the owner's behalf
+
+### How to Enable It
+
+1. Open the details page for the deposit you want to protect.
+2. Find the **Chargeback Protection** toggle in the deposit controls section.
+3. Turn the toggle on.
+4. Confirm both wallet prompts to finish setup.
+
+:::info Expect two wallet prompts
+Turning on Chargeback Protection sends two on-chain transactions. The first turns on protection for the deposit, and the second authorizes Peer's Pay relayer to fill it. Both transactions must complete before the deposit becomes protected.
+:::
+
+### What the Protected Badge Means
+
+After Chargeback Protection is enabled, a **Protected** badge appears:
+
+- In the deposit list
+- In the deposit header
+- On individual orders
+
+This badge confirms that only validated orders can fill the deposit.
+
+### When to Use It
+
+Chargeback Protection is a good fit for payment methods where disputes and reversals are more common, such as:
+
+- PayPal
+- Cash App
+
+:::warning Lower-risk payment methods may not need it
+Chargeback Protection is less important for platforms like Revolut, Wise, and Monzo, where payments settle instantly and chargebacks are not part of the normal flow.
+:::
+
+### Trade-offs
+
+Chargeback Protection improves safety, but it can reduce how many buyers are able to fill your deposit. Only orders routed through Pay can take the deposit, so fills may be slower.
+
+If you care more about safety than speed, turn it on. If you care more about getting filled as quickly as possible, you may prefer to leave it off.


### PR DESCRIPTION
## Summary

- Adds a new guide at `guides/for-sellers/chargeback-protection.md` explaining what Chargeback Protection does, who can enable it, and how to toggle it on
- Adds the guide to `guides-sidebars.js` after `manual-releases` in the For Sellers section
- Covers trade-offs (safety vs fill speed) and which payment platforms benefit most

## Why

Sellers on high-risk payment platforms (PayPal, Cash App) need clear guidance on the Chargeback Protection feature to reduce dispute risk. Closes #52.

## Changes

**New guide** (`guides/for-sellers/chargeback-protection.md`):
- What Chargeback Protection is and how Pay signal relayer validation works
- Who can enable it (deposit owners, vault delegates)
- Step-by-step enable flow with wallet prompt expectations
- Protected badge locations (deposit list, header, orders)
- When to use it (high-risk vs low-risk platforms)
- Trade-offs between safety and fill speed

**Sidebar** (`guides-sidebars.js`):
- Added `for-sellers/chargeback-protection` after `for-sellers/manual-releases`

## Test plan

Not run — documentation-only change. Build gate (`yarn build`) should be run before merge.