### PR TITLE
docs: add NEAR Intents bridge guide for non-EVM offramps

### DIFF
--- a/guides-sidebars.js
+++ b/guides-sidebars.js
@@ -14,6 +14,7 @@ module.exports = {
         'for-buyers/complete-guide-to-onboarding',
         'for-buyers/handling-verification-issues',
         'for-buyers/guide-to-partial-release',
+        'for-buyers/bridge-to-non-evm-chains',
         'for-buyers/reputation'
         ],
     },

--- a/guides/for-buyers/bridge-to-non-evm-chains.md
+++ b/guides/for-buyers/bridge-to-non-evm-chains.md
@@ -1,0 +1,62 @@
+---
+id: bridge-to-non-evm-chains
+title: Bridge USDC to Non-EVM Chains
+---
+
+# Bridge USDC to Non-EVM Chains
+
+Peer lets you convert USDC on Base to non-EVM cryptocurrencies using the NEAR Intents cross-chain bridge. Send USDC from your wallet and receive native crypto on the destination chain.
+
+## Supported Chains
+
+| Chain | Token | Address Format |
+|-------|-------|---------------|
+| Zcash | ZEC | Transparent (`t1...` / `t3...`) or Sapling shielded (`zs1...`) |
+| Dogecoin | DOGE | Starts with `D`, 34 characters |
+| Litecoin | LTC | Starts with `L`, `M`, or `ltc1` |
+| XRP | XRP | Starts with `r`, 25-35 characters |
+| Cardano | ADA | Starts with `addr1` |
+| Dash | DASH | Starts with `X`, 34 characters |
+
+## How to Bridge
+
+### Step 1: Open the Bridge
+
+Go to [app.peer.xyz](https://app.peer.xyz) and select the **Bridge** tab.
+
+### Step 2: Select Destination Chain
+
+Choose your destination chain from the dropdown (e.g. Zcash, Dogecoin, Litecoin).
+
+### Step 3: Enter Amount
+
+Enter the amount of USDC you want to bridge. The app displays a quote showing how much crypto you'll receive on the destination chain.
+
+### Step 4: Enter Destination Address
+
+Paste your destination chain wallet address. Make sure the address format matches the chain you selected (see the table above).
+
+### Step 5: Review and Confirm
+
+Review the quoted output amount and estimated completion time, then confirm the swap.
+
+### Step 6: Wait for Completion
+
+The bridge typically takes 2-10 minutes depending on the destination chain. Track the status in the app until the swap shows as complete.
+
+## Fees
+
+The bridge charges a **0.95% fee** on each swap. This fee is already included in the quoted output amount you see before confirming.
+
+## Troubleshooting
+
+:::warning
+
+**Swap failed or stuck?**
+
+- **Failed swaps**: If a swap fails, funds are automatically refunded to your Base wallet address. No action needed.
+- **Slow completion**: Bridge times vary by chain and network conditions. If a swap takes longer than expected, check the status in the app before taking any action.
+- **Invalid address error**: Double-check that your destination address format matches the requirements for your selected chain in the table above.
+- **Still need help?** Join [Peer Telegram](https://t.me/+XDj9FNnW-xs5ODNl) for support.
+
+:::


### PR DESCRIPTION
## Summary

- Add buyer guide for the NEAR Intents bridge feature (`guides/for-buyers/bridge-to-non-evm-chains.md`)
- Covers 6 non-EVM destination chains: Zcash, Dogecoin, Litecoin, XRP, Cardano, Dash
- Documents step-by-step flow, address formats, fee structure (0.95%), and troubleshooting
- Add sidebar entry in `guides-sidebars.js`

Closes #57

## Why

The NEAR Intents bridge feature shipped in zkp2p-clients across PRs #548-#645 (April 2-21) with zero user-facing documentation on docs.peer.xyz.

## Test plan

- [x] `yarn build` passes with no errors or broken link warnings
- [ ] Verify page renders correctly at `/guides/for-buyers/bridge-to-non-evm-chains`
- [ ] Verify sidebar navigation shows the new entry under "For Buyers"