### PR TITLE
fix: remove duplicate developer prefix from intent hooks slug

### DIFF
--- a/developer/post-intent-hooks.md
+++ b/developer/post-intent-hooks.md
@@ -1,6 +1,6 @@
 ---
 title: Intent Hooks (V3)
-slug: /developer/api/v3/post-intent-hooks
+slug: /api/v3/post-intent-hooks
 ---
 
 # Intent Hooks


### PR DESCRIPTION
## Summary

- Fix broken sidebar link for Intent Hooks page that resolved to `/developer/developer/api/v3/post-intent-hooks` (double `developer/` prefix)
- The `slug` frontmatter in `post-intent-hooks.md` included `/developer/` but the docs plugin already sets `routeBasePath: 'developer'`, causing the prefix to double
- Removed the redundant `/developer` from the slug so the page builds at the correct `/developer/api/v3/post-intent-hooks`

## Test plan

- [x] `yarn build` passes
- [x] Page builds at `/developer/api/v3/post-intent-hooks` (verified in `build/`)
- [x] Double path `/developer/developer/...` no longer exists in build output
- [x] Sidebar link in adjacent pages points to correct URL