### PR TITLE
docs: remove stale telegram username references from buyer guide and offramp docs

### DIFF
--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -159,8 +159,6 @@ The expected `depositData` shape for each platform is:
 | Luxon | `luxon` | `{ luxonUsername: 'maker@example.com' }` | Use a lowercase Luxon email address. |
 | N26 | `n26` | `{ iban: 'DE89370400440532013000' }` | Pass a valid IBAN with spaces removed. |
 
-If you want to mirror the web app's posting flow exactly, you can also include `telegramUsername` alongside the required platform-specific field, but the processor-specific key above is the part curator actually validates.
-
 ```ts
 import { getPaymentMethodsCatalog, PLATFORM_METADATA, PAYMENT_PLATFORMS } from '@zkp2p/sdk';
 

--- a/guides/for-buyers/handling-verification-issues.md
+++ b/guides/for-buyers/handling-verification-issues.md
@@ -26,14 +26,13 @@ When you buy USDC or crypto through ZKP2P, the platform tries to automatically v
 2. If you just installed it, you might need to **refresh the page**  
 3. The extension needs proper permissions to access your payment data
 
-#### Contact the Seller or Support via Telegram
+#### Contact Support
 
 If verification continues to fail after multiple attempts:
 
-- Contact the seller or support through Telegram  
-- Sellers typically list their Telegram username in their deposit details  
+- Reach out in the [Peer Telegram](https://t.me/+XDj9FNnW-xs5ODNl) community group or [Discord](https://discord.gg/4hNVTv2MbH) for help  
 
-Send the following info to the seller:
+Send the following info to support:
 
 - Your order ID or transaction details  
 - Screenshot of your payment receipt/confirmation  


### PR DESCRIPTION
## Summary
- Removes stale references to sellers listing Telegram usernames in deposit details from the buyer verification guide and offramp developer docs
- The `telegramUsername` field was removed from the deposit creation flow in zkp2p/zkp2p-clients#671; PR #62 cleaned up the seller guide but missed these two files

Closes #63

## Test plan
- [x] `yarn build` passes
- [x] `grep -rn "telegramUsername\|telegram username" guides/ developer/` returns no hits
- [ ] Verify buyer guide "Contact Support" section reads correctly on docs site
- [ ] Verify offramp integration doc table section flows without the removed sentence