### PR TITLE
add paypal business account warning to seller guide

### DIFF
--- a/guides/for-sellers/provide-liquidity-sell-usdc.md
+++ b/guides/for-sellers/provide-liquidity-sell-usdc.md
@@ -106,6 +106,10 @@ Enter your username/account details for the selected platform:
 PayPal requires identity verification through the PeerAuth browser extension (v0.4.13+). When you select PayPal, you will be prompted to complete extension-based verification before your deposit goes live. This is the same flow used for Wise.
 :::
 
+:::warning PayPal Business Accounts Not Supported
+PayPal Business accounts are not supported. Business accounts redirect to a different page during PeerAuth verification, causing registration to fail silently. Use a personal PayPal account instead.
+:::
+
 ![Provide Step 10](/img/provide-liquidity/ProvideStep9.png)
 
 


### PR DESCRIPTION
## Summary

- Adds a `:::warning` admonition to the seller guide noting that PayPal Business accounts are not supported
- Placed immediately after the existing PeerAuth extension info block in the PayPal section

## Why

zkp2p-clients#681 shipped a PayPal Business disclaimer in the app UI, but the seller guide had no mention of this limitation. Sellers using Business accounts hit a silent failure during PeerAuth registration because Business accounts redirect to a different page.

## Changes

- **guides/for-sellers/provide-liquidity-sell-usdc.md**: Added warning admonition after the existing PayPal `:::info` block (after line 107)

## Test plan

Not run — documentation-only change. Build gate (`yarn build`) should be run by CI.

Closes #65