### PR TITLE
docs: add backup code-linking flow to notifications guide

### DIFF
--- a/.oneshot-pr-body.txt
+++ b/.oneshot-pr-body.txt
@@ -1,20 +1,19 @@
 ## Summary
-- Remove jargon ('leveraging', 'utilize', 'streamline', 'comprehensive', 'seamlessly', 'It is important to note') across documentation and JSX copy, replacing it with direct alternatives
-- Tighten prose: cut throat-clearing intros, convert passive voice to active, remove filler phrases
-- Fix typos ('protoclol' → 'protocol', '20225' → '2025', 'commited' → 'committed', 'they key' → 'the key')
-- Correct `UnifiedPaymentVerifier` → `UnifiedPaymentVerifierV2` in V3 migration guide
+
+- Adds a **Backup Linking via Code** subsection under the existing **Linking Telegram** heading in the seller notifications guide
+- Documents the alternate code-based Telegram linking flow (expand → generate code → open Telegram → send `/link <code>`) including expiry and manual fallback
+- UI strings verified against `TelegramLinkCode.tsx` in `zkp2p-clients` origin/main
 
 ## Why
-Documentation accumulated jargon and filler that made it harder to read. A full editorial pass brings every doc to a consistent, direct voice and fixes factual inaccuracies in technical references.
+
+PR #72 shipped the notifications guide before the backup code-linking flow landed in `zkp2p-clients` PR #698 (merged 2026-04-24). Sellers who hit widget failures had no documented fallback path.
 
 ## Changes
-- **Blog posts** (`blog/`, `src/pages/blog/`): Light touch — replaced 'leveraging' with 'using', 'utilize' with 'use', 'seamlessly' with direct phrasing, fixed missing newlines at EOF, corrected year typo in V3 intro
-- **User guides** (`guides/`): Rewrote wordy intros ('This guide will walk you through...' → direct descriptions), removed hedge language, tightened instructions
-- **Protocol docs** (`protocol/`): Replaced slop terms, fixed typo in 'protoclol', corrected contract name in migration guide, tightened technical descriptions
-- **Developer docs** (`developer/`): Replaced 'facilitate' with 'enable' in provider integration overview
-- **Internal instruction files** (`guides/`, `src/`, `src/brand/`): Removed flagged terms while preserving instructional tone
-- **JSX blog pages** (`src/pages/blog/`): Mirrored all prose changes from markdown sources, fixed missing EOF newlines
+
+- `guides/for-sellers/notifications.md` — new `#### Backup Linking via Code` subsection inserted after the existing Linking Telegram bullets, before Alert Preferences
 
 ## Test plan
-- `yarn typecheck` (not available: no `typecheck` script is defined)
-- `yarn build`
+
+- `yarn build` — succeeded, no broken links or build errors
+
+Closes #75

--- a/.oneshot-pr-title.txt
+++ b/.oneshot-pr-title.txt
@@ -1,1 +1,1 @@
-docs: deslop and tighten prose across all documentation
+docs: add backup code-linking flow to notifications guide

--- a/guides/for-sellers/notifications.md
+++ b/guides/for-sellers/notifications.md
@@ -18,6 +18,16 @@ Manage Telegram alerts for orders and deposits from the notifications sidebar.
 - Open the notifications sidebar and connect your Telegram account
 - You must link Telegram before you can receive alerts
 
+#### Backup Linking via Code
+
+If the Telegram login widget does not load or fails to authorize, use the alternate code flow that appears directly below the widget.
+
+- Click **Use a code instead** to expand the alternate section.
+- Press **Generate linking code** to get a short one-time code. Each code expires after a few minutes. The **Expires in** timer shows the remaining time.
+- Press **Open Telegram**. The app opens with `/link <code>` pre-filled. Send the message to finish linking.
+- If the button cannot open Telegram on your device, DM the bot directly and send `/link <code>` yourself.
+- If the code expires before you use it, press **Generate new code** to get a fresh one.
+
 ### Alert Preferences
 
 - Toggle order alerts on or off from the sidebar controls


### PR DESCRIPTION
## Summary

- Adds a **Backup Linking via Code** subsection under the existing **Linking Telegram** heading in the seller notifications guide
- Documents the alternate code-based Telegram linking flow (expand → generate code → open Telegram → send `/link <code>`) including expiry and manual fallback
- UI strings verified against `TelegramLinkCode.tsx` in `zkp2p-clients` origin/main

## Why

PR #72 shipped the notifications guide before the backup code-linking flow landed in `zkp2p-clients` PR #698 (merged 2026-04-24). Sellers who hit widget failures had no documented fallback path.

## Changes

- `guides/for-sellers/notifications.md` — new `#### Backup Linking via Code` subsection inserted after the existing Linking Telegram bullets, before Alert Preferences

## Test plan

- `yarn build` — succeeded, no broken links or build errors

Closes #75