### PR TITLE
docs: add seller guide for vault delegation

### DIFF
--- a/.oneshot-pr-body.txt
+++ b/.oneshot-pr-body.txt
@@ -1,21 +1,20 @@
 ## Summary
 
-- Adds a new seller guide (`guides/for-sellers/monitor-your-deposit.md`) covering the deposit table columns and the deposit detail StatsBar shipped in zkp2p-clients PR #716.
-- Registers the new guide in the For Sellers sidebar and index page.
+- New guide `guides/for-sellers/delegate-to-a-vault.md` covering what vault delegation does, how to enable it, how to choose a vault, and post-deposit states.
+- Wired into `guides-sidebars.js` after `manual-releases` and before `notifications` in the For Sellers section.
+- All UI labels verified against `zkp2p-clients` source (ExpressMode, AdvancedMode, VaultDelegationPanel, VaultDelegationCTA).
 
 ## Why
 
-Sellers had no documentation for interpreting the deposit table columns (Remaining, Taken utilization bar, PnL, status badges) or the six-stat detail view (Available, Volume, Utilization, Fills, Realized PnL, APR). This fills that gap so sellers can tune spreads with confidence.
+Vault delegation shipped in zkp2p-clients commit 10f00f53 (2026-04-27) with zero docs coverage. Sellers need a reference for enabling delegation, choosing a vault, and understanding post-deposit follow-up states.
 
-Closes zkp2p/docs#86
+Closes zkp2p/docs#88
 
 ## Changes
 
-- **`guides/for-sellers/monitor-your-deposit.md`** — New guide with three sections: reading the deposits table, reading the deposit detail StatsBar (with exact tooltip strings), and status badge definitions.
-- **`guides/for-sellers/index.md`** — Added link to the new guide in the Get Started list.
-- **`guides-sidebars.js`** — Added `for-sellers/monitor-your-deposit` after `calculating-apr` in the For Sellers sidebar group.
+- **`guides/for-sellers/delegate-to-a-vault.md`** — New doc covering: what delegation does (with verbatim tip quote), who it's for (cross-link to ARM), toggle location (Express + Advanced, phase flag note), vault selection (sort tabs, pagination, card metrics, empty state), post-deposit states (Express and Advanced CTA labels, success/unavailable/error states), and next steps (vaults page, vault manager guide).
+- **`guides-sidebars.js`** — Added `for-sellers/delegate-to-a-vault` to the For Sellers items array between `manual-releases` and `notifications`.
 
 ## Test plan
 
-- `yarn build` — succeeded with no broken-link warnings or errors.
-- `git diff --stat origin/main...HEAD` — confirmed only the three expected files changed (89 insertions).
+- `yarn build` — succeeded with zero broken-link warnings.

--- a/.oneshot-pr-title.txt
+++ b/.oneshot-pr-title.txt
@@ -1,1 +1,1 @@
-docs: add seller guide for deposit monitoring metrics
+docs: add seller guide for vault delegation

--- a/guides-sidebars.js
+++ b/guides-sidebars.js
@@ -28,6 +28,7 @@ module.exports = {
         'for-sellers/calculating-apr',
         'for-sellers/monitor-your-deposit',
         'for-sellers/manual-releases',
+        'for-sellers/delegate-to-a-vault',
         'for-sellers/notifications',
         {
           type: 'category',

--- a/guides/for-sellers/delegate-to-a-vault.md
+++ b/guides/for-sellers/delegate-to-a-vault.md
@@ -1,0 +1,56 @@
+---
+id: delegate-to-a-vault
+title: Delegate a Deposit to a Vault
+---
+
+# Delegate a Deposit to a Vault
+
+Vault delegation lets a vault manager adjust your rates for you. Your USDC does not move to the vault manager. Delegation changes rate management, not custody.
+
+### What delegation does
+
+When you delegate a deposit, the vault manager updates your pricing on your behalf. This helps you stay competitive without manually changing rates yourself.
+
+Peer describes it like this:
+
+> Tip: Vaults auto-adjust your rates to stay competitive. Your deposit stays in your wallet.
+
+### Who is this for
+
+Use delegation if you do not want to manage rates yourself.
+
+If you want to keep control of your own spreads and floor rates, use [Automated Rate Management (ARM)](automated-rate-management.md) instead.
+
+### How to turn it on
+
+On the new-deposit form, open the options stack and turn on `Delegate to Vault`. The toggle is available in both Express and Advanced mode.
+
+The toggle is behind the `phase3VaultsEnabled` phase flag. If you do not see it yet, it has not been enabled for you.
+
+### Choosing a vault
+
+You can sort the vault list by `Volume` or `APR`. The panel shows up to three vaults at a time. If there are more matches, use the pagination dots to move between pages.
+
+Each vault card shows `Vol`, `APR`, and `Managed`. Verified vaults show a green check.
+
+If no vault matches your payment method and currency, you will see `No compatible vaults`.
+
+### What happens after deposit
+
+After your deposit is created, you will see a vault-delegation follow-up state for the vault you selected.
+
+In Express mode, the action button reads `DELEGATE TO VAULT`. While the transaction is pending, it changes to `DELEGATING...`. In Advanced mode, the same step uses `Delegate to vault` and `Delegating...`.
+
+When delegation succeeds, the deposit shows `Delegated` with the vault name.
+
+In Express mode, if the vault cannot accept the delegation, the follow-up state is `Deposit created. Vault delegation unavailable` and the button changes to `VIEW DEPOSIT`.
+
+In Express mode, if the delegation transaction fails, the error state is `Vault delegation failed`. In Advanced mode, the follow-up card shows the returned error and lets you retry.
+
+### Where to go next
+
+Browse live vaults on [Explore vaults](https://peer.xyz/vaults).
+
+If you want the manager-side view, read [For Vault Managers](../for-vault-managers/index.md).
+
+➡️ _Next: [Notifications and Alerts](notifications.md)_

--- a/guides/for-sellers/delegate-to-a-vault.md
+++ b/guides/for-sellers/delegate-to-a-vault.md
@@ -9,9 +9,7 @@ Vault delegation lets a vault manager adjust your rates for you. Your USDC does 
 
 ### What delegation does
 
-When you delegate a deposit, the vault manager updates your pricing on your behalf. This helps you stay competitive without manually changing rates yourself.
-
-Peer describes it like this:
+When you delegate a deposit, the vault manager updates your pricing on your behalf. Your USDC stays in your wallet.
 
 > Tip: Vaults auto-adjust your rates to stay competitive. Your deposit stays in your wallet.
 
@@ -43,7 +41,7 @@ In Express mode, the action button reads `DELEGATE TO VAULT`. While the transact
 
 When delegation succeeds, the deposit shows `Delegated` with the vault name.
 
-In Express mode, if the vault cannot accept the delegation, the follow-up state is `Deposit created. Vault delegation unavailable` and the button changes to `VIEW DEPOSIT`.
+In Express mode, if the vault cannot accept the delegation, the follow-up state is `Vault delegation unavailable` and the button changes to `VIEW DEPOSIT`.
 
 In Express mode, if the delegation transaction fails, the error state is `Vault delegation failed`. In Advanced mode, the follow-up card shows the returned error and lets you retry.
 


### PR DESCRIPTION
## Summary

- New guide `guides/for-sellers/delegate-to-a-vault.md` covering what vault delegation does, how to enable it, how to choose a vault, and post-deposit states.
- Wired into `guides-sidebars.js` after `manual-releases` and before `notifications` in the For Sellers section.
- All UI labels verified against `zkp2p-clients` source (ExpressMode, AdvancedMode, VaultDelegationPanel, VaultDelegationCTA).

## Why

Vault delegation shipped in zkp2p-clients commit 10f00f53 (2026-04-27) with zero docs coverage. Sellers need a reference for enabling delegation, choosing a vault, and understanding post-deposit follow-up states.

Closes zkp2p/docs#88

## Changes

- **`guides/for-sellers/delegate-to-a-vault.md`** — New doc covering: what delegation does (with verbatim tip quote), who it's for (cross-link to ARM), toggle location (Express + Advanced, phase flag note), vault selection (sort tabs, pagination, card metrics, empty state), post-deposit states (Express and Advanced CTA labels, success/unavailable/error states), and next steps (vaults page, vault manager guide).
- **`guides-sidebars.js`** — Added `for-sellers/delegate-to-a-vault` to the For Sellers items array between `manual-releases` and `notifications`.

## Test plan

- `yarn build` — succeeded with zero broken-link warnings.