### PR TITLE
docs: remove amountUsdc deeplink param (exact-USDC-output retirement)

### DIFF
--- a/developer/integrate-zkp2p/integrate-redirect-onramp.md
+++ b/developer/integrate-zkp2p/integrate-redirect-onramp.md
@@ -123,7 +123,6 @@ Pass these parameters as an object to `peerExtensionSdk.onramp()`. The SDK build
 | `inputCurrency` | (Optional) Input currency user wants to swap. Defaults to the user's local currency when available, otherwise USD. | String | `inputCurrency=USD` |
 | `inputAmount` | (Optional) Amount of input currency the user wants to swap | String or number (up to 6 decimal places) | `inputAmount=12.34` |
 | `paymentPlatform` | (Optional) Preferred payment platform for the initial quote. The user can still choose a different one in the extension. | String | `paymentPlatform=venmo` |
-| `amountUsdc` | (Optional) Exact USDC output amount in base units (`1000000` = `1` USDC). Requires `recipientAddress`. | String, number, or bigint | `amountUsdc=1000000` |
 | `toToken` | (Optional) Output token the user will onramp to | String (Has to be in the format explained below) | `toToken=8453:0x0000000000000000000000000000000000000000` |
 | `recipientAddress` | (Optional) Address to which the output tokens will be sent. | String | `recipientAddress=0xf39...66` |
 | `intentHash` | (Optional) Existing intent hash to reopen directly in the send-payment step. Must be a `0x`-prefixed 32-byte hex string. | String | `intentHash=0xabc...123` |
@@ -244,25 +243,6 @@ peerExtensionSdk.onramp({
   inputAmount: '10',
   paymentPlatform: 'revolut',
   toToken: '1:0x0000000000000000000000000000000000000000',
-  recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
-});
-```
-
-#### Onramp Exact USDC Amount
-
-Onramp exactly 1 USDC on Base to a recipient address. Users can choose their preferred currency and payment method. The best available quote is fetched and displayed so the user can complete the order.
-
-:::note
-- Exact amount output is currently only available for USDC and not for other tokens
-- `amountUsdc` overrides any output token (`toToken`) and input (`inputAmount`) params
-- `recipientAddress` is required for the exact output flow
-:::
-
-```ts
-peerExtensionSdk.onramp({
-  referrer: 'Rampy Pay',
-  referrerLogo: 'https://demo.peer.xyz/Rampy_logo.svg',
-  amountUsdc: '1000000',
   recipientAddress: '0x84e113087C97Cd80eA9D78983D4B8Ff61ECa1929',
 });
 ```

--- a/static/onramp-llm.md
+++ b/static/onramp-llm.md
@@ -65,7 +65,6 @@ peerSdk.onramp({
 | `inputCurrency` | Optional | Fiat currency code (e.g. `USD`, `EUR`). Defaults to user's locale |
 | `inputAmount` | Optional | Fiat amount to convert (up to 6 decimal places) |
 | `paymentPlatform` | Optional | Preferred payment method (e.g. `venmo`, `revolut`) — not enforced |
-| `amountUsdc` | Optional | Exact USDC output amount in base units (e.g. `1000000` = 1 USDC). Overrides `toToken` and `inputAmount`. Requires `recipientAddress` |
 | `intentHash` | Optional | Existing `0x`-prefixed 32-byte intent hash to reopen directly in the send-payment step |
 
 ### Supported chains for `toToken`


### PR DESCRIPTION
## Summary

Removes documentation for the `amountUsdc` onramp deeplink param, which is being retired across all clients.

- Strips the param row from the deeplink parameter table
- Deletes the "Onramp Exact USDC Amount" example and its `:::note` admonition
- Removes the corresponding row in `static/onramp-llm.md` (the LLM integration prompt)

## Why

`amountUsdc` used to trigger a reverse-quote ("how much fiat to receive exactly N USDC") and lock the fiat/recipient/token fields. The companion client PRs strip that flow entirely. Without this PR, the public docs would advertise a feature the clients no longer implement.

## Coordinated removal -- linked series

This PR is one of four that together retire the `amountUsdc` (exact-USDC-output) onramp deeplink. They should land together (or close to it):

- [ ] zkp2p/zkp2p-clients#757 -- web
- [ ] zkp2p/zkp2p-clients#756 -- extension
- [ ] zkp2p/docs#92 -- this PR
- [ ] zkp2p/zkp2p-demo#9 -- demo form field + Exact USDC preset

Suggested merge order: docs (this) -> demo -> extension -> web, so any partner re-reading the spec sees the new contract before the clients flip.

## Test plan

- [x] `grep -n amountUsdc developer/integrate-zkp2p/integrate-redirect-onramp.md static/onramp-llm.md` returns no hits
- [ ] `yarn build` (docs preview) -- pending CI
- [ ] Verify the parameter table renders cleanly with the row removed