### PR TITLE
docs(TEE): Document SAR as a TEE-only flow

### DIFF
--- a/protocol-sidebars.js
+++ b/protocol-sidebars.js
@@ -24,6 +24,7 @@ module.exports = {
           ],
         },
         { type: 'doc', id: 'v3/v3-attestation-service', label: 'Attestation Service' },
+        { type: 'doc', id: 'v3/v3-seller-automated-release', label: 'Seller Automated Release' },
         { type: 'doc', id: 'v3/v3-deployments', label: 'Deployments' },
         { type: 'doc', id: 'v3/v3-migration', label: 'Migration (V2 → V3)' },
       ],

--- a/protocol/peerauth-extension/index.md
+++ b/protocol/peerauth-extension/index.md
@@ -2,7 +2,7 @@
 title: PeerAuth Extension
 ---
 
-ZKP2P uses a cryptographic technology called zkTLS. zkTLS allows users to securely and privately export data similar to [OAuth](https://oauth.net/2/) but for any website even if there are no public APIs. This is powerful because users can now free their data from monopolies held by the largest providers such as Google or Facebook.
+ZKP2P uses a cryptographic technology called zkTLS for the buyer-generated proof path. zkTLS allows users to securely and privately export data similar to [OAuth](https://oauth.net/2/) but for any website even if there are no public APIs. This is powerful because users can now free their data from monopolies held by the largest providers such as Google or Facebook.
 
 The flow uses Zero Knowledge Proofs (ZKP) and Multi-Party Computation (MPC) to let users selectively share their data in a verifiable, privacy-preserving way.
 
@@ -22,6 +22,8 @@ PeerAuth plays a key role in helping buyers authenticate their payment transacti
 -   Fetching Necessary Cookies: The extension retrieves the relevant cookies from sites you're logged into. These cookies are used to generate proof of web2 data, such as previous 10 Venmo transactions.
 
 ***Note*:** All data stays on the user's device — only zero-knowledge proofs leave. Private data not relevant to proving validity is redacted before sharing with our deployed verifier.
+
+Seller Automated Release is TEE-based and does not use PeerAuth for credential upload or seller-side verification.
 
 Currently, PeerAuth only supports ZKP2P as its first integration, but the extension is generalized to support OAuth into any website.
 

--- a/protocol/peerauth-extension/zk-tls.md
+++ b/protocol/peerauth-extension/zk-tls.md
@@ -9,7 +9,6 @@ title: zkTLS
 
 At ZKP2P, we make heavy use of zkTLS techniques to prove authenticity of data while preserving user privacy. zkTLS enables us to port any data from the web served through TLS1.2 and TLS1.3 to smart contracts. In particular, there are 2 techniques: TLSNotary (MPC-TLS) and TLSProxy (proxy based approach e.g [Reclaim Protocol](https://reclaimprotocol.org/))
 
-
 ## TLSNotary
 
 ### Notary

--- a/protocol/v3/overview.md
+++ b/protocol/v3/overview.md
@@ -8,7 +8,8 @@ title: ZKP2P Protocol V3 — Overview
 ZKP2P V3 is the current production protocol. It enables faster, more flexible, and easier-to-integrate P2P exchange by moving proof verification off-chain into a standardized Attestation Service, and by consolidating on-chain verification logic into a single Unified Payment Verifier. The protocol remains fully non-custodial: contracts only move funds, while verification and orchestration are modular and replaceable.
 
 ### What's new vs V2
-- Off-chain verification: the Attestation Service validates provider proofs (e.g., Reclaim/TLSNotary), normalizes them, and signs an EIP-712 PaymentAttestation used on-chain.
+- Off-chain verification: the Attestation Service validates payment evidence, normalizes it, and signs an EIP-712 PaymentAttestation used on-chain.
+- Seller Automated Release: sellers can upload encrypted platform credentials once; the TEE later verifies matching payments and signs the V3 attestation.
 - Single on-chain verifier: `UnifiedPaymentVerifierV2` validates the EIP-712 signature and enforces protocol rules (intent bounds, nullifiers, release capping).
 - Cleaner intent path: the gating service signs intents with richer context (payment method, fiat currency, conversion rate, orchestrator/escrow addresses) to reduce round trips.
 - Extensible: adding providers is purely off-chain (transformers) with a stable on-chain attestation format.
@@ -23,7 +24,7 @@ ZKP2P V3 is the current production protocol. It enables faster, more flexible, a
 - Buyer (on-ramper): pays off-chain and receives on-chain tokens.
 - Seller (off-ramper): supplies token liquidity in Escrow and receives off-chain fiat.
 - Gating Service (Curator): authorizes intent creation for sellers, returns payee details and a signature.
-- Attestation Service: verifies provider proofs and issues PaymentAttestations.
+- Attestation Service: verifies payment evidence and issues PaymentAttestations.
 - On-chain: EscrowV2, OrchestratorV2, OrchestratorRegistry, RateManagerV1, UnifiedPaymentVerifierV2, AttestationVerifier (witness set).
 - Pre-intent hooks run before fund locking during `signalIntent`.
 
@@ -32,7 +33,7 @@ ZKP2P V3 is the current production protocol. It enables faster, more flexible, a
 2) Intent signing: client calls the gating API (Curator v2 endpoint) to obtain `gatingServiceSignature` tied to deposit/payment method/fiat.
 3) Signal Intent (on-chain): call `OrchestratorV2.signalIntent(...)` with depositId, amount, to, paymentMethod, fiatCurrency, conversionRate, referralFees, `gatingServiceSignature`. Pre-intent hooks validate the intent before state changes.
 4) Pay off-chain: buyer pays seller's off-chain identifier (hashed on-chain as `payeeDetails`).
-5) Generate proof: via PeerAuth; send proof + intent details to Attestation Service.
+5) Verify payment through buyer proof generation or Seller Automated Release. In SAR, the TEE decrypts the seller's encrypted credential bundle, queries the payment platform, and verifies the payment.
 6) Attestation: Attestation Service returns a `PaymentAttestation` EIP-712 signature and an ABI-encoded payload.
 7) Fulfill (on-chain): call `OrchestratorV2.fulfillIntent({ paymentProof: abi.encode(PaymentAttestation), intentHash, ... })`. Orchestrator routes to `UnifiedPaymentVerifierV2` to check the attestation, then unlocks and transfers tokens.
 

--- a/protocol/v3/seller-automated-release.md
+++ b/protocol/v3/seller-automated-release.md
@@ -1,0 +1,180 @@
+---
+id: v3-seller-automated-release
+title: Seller Automated Release
+---
+
+# Seller Automated Release
+
+## TEE
+
+Seller Automated Release (SAR) is an enclave-resident verification flow. Seller credential material is encrypted to an upload key that is generated inside the AWS Nitro Enclave. The enclave validates that credential material against the payment platform, converts it into an encrypted bundle, and later uses the bundle to verify payments and sign a V3 `PaymentAttestation`.
+
+The important primitive is the TEE boundary: plaintext seller credentials are only available inside the measured enclave process.
+
+## Enclave Responsibilities
+
+| Responsibility | Detail |
+|---|---|
+| Generate upload key | The enclave generates an RSA seller-upload key at startup. The private key stays in enclave memory. |
+| Prove the upload key | The public upload key is embedded in the Nitro attestation document so clients can verify it before encryption. |
+| Decrypt uploads | Seller credential uploads are compact JWE payloads encrypted to the attested upload key. |
+| Validate credentials | The enclave uses the uploaded material to prove live access to the claimed payment account. |
+| Encrypt bundles | Validated credentials are encrypted with a per-bundle AES-256-GCM key wrapped by AWS KMS. |
+| Verify payments | The enclave decrypts the bundle in memory, queries the platform, normalizes the payment, and runs verifier checks. |
+| Sign attestations | The enclave signs the final EIP-712 `PaymentAttestation` for on-chain settlement. |
+
+## Nitro Verification Package
+
+Clients should use `@zkp2p/zkp2p-attestation` to verify the Nitro attestation document before encrypting seller credentials.
+
+```bash
+npm install @zkp2p/zkp2p-attestation
+```
+
+The package verifies nonce binding, freshness, the AWS Nitro certificate chain, the COSE signature, and the trusted PCR8 pin. It then extracts the enclave's attested seller-upload public key.
+
+```ts
+import { createNitroAttestationClient } from "@zkp2p/zkp2p-attestation";
+
+const nitro = createNitroAttestationClient({
+  environment: "staging", // or "production"
+});
+
+const verified = await nitro.fetchAndVerifyAttestation();
+
+console.log(verified.attestedSellerUploadKey.publicKeySha256Hex);
+console.log(verified.payload.pcr8Hex);
+```
+
+For the normal upload path, the package can verify the enclave and create the compact JWE in one call:
+
+```ts
+const encryptedUpload = await nitro.createEncryptedSellerCredentialUpload({
+  payeeId: "1130030979",
+  sessionMaterial: {
+    apiToken: "<wise-api-token>",
+    profileId: "41246868",
+    balanceId: "61249083",
+    currency: "EUR",
+  },
+});
+```
+
+Advanced callers can split verification from encryption within a single session:
+
+```ts
+const verified = await nitro.fetchAndVerifyAttestation();
+
+const encryptedUpload = await nitro.encryptSellerCredentialUpload({
+  key: verified.attestedSellerUploadKey,
+  payeeId: "1130030979",
+  sessionMaterial: {
+    apiToken: "<wise-api-token>",
+    profileId: "41246868",
+    balanceId: "61249083",
+    currency: "EUR",
+  },
+});
+```
+
+Do not cache the attested upload key across enclave restarts. A restart generates a new upload key, and ciphertext sealed to the old key fails closed.
+
+## Upload Sealing
+
+Seller credential material is sealed as compact JWE with:
+
+| Layer | Value |
+|---|---|
+| Key management | `RSA-OAEP-256` |
+| Content encryption | `A256GCM` |
+| Recipient key | Seller-upload public key from the verified Nitro document |
+
+The encrypted plaintext includes:
+
+| Field | Purpose |
+|---|---|
+| `payeeId` | Platform-native seller recipient identifier. |
+| `sessionMaterial` | Platform-specific credential material. |
+| `boundPubKeySha256` | SHA-256 of the attested DER SPKI upload key. |
+| `issuedAtMs` | Upload freshness timestamp. |
+| `jweId` | Unique replay-rejection identifier. |
+
+The enclave rejects uploads that are stale, replayed, or bound to a different upload key.
+
+## Credential Bundle Encryption
+
+After live validation, the enclave encrypts the credential into a reusable bundle.
+
+| Bundle layer | Mechanism |
+|---|---|
+| Data encryption key | Fresh AES-256 key from AWS KMS `GenerateDataKey`. |
+| Credential ciphertext | AES-256-GCM over `{ payeeId, credential }`. |
+| Wrapped key | KMS ciphertext blob for later enclave decrypt. |
+| Bundle signature | EIP-712 signature over the encrypted bundle fields. |
+| Validation timestamp | `credentialValidatedAt`, sampled immediately after platform validation succeeds. |
+
+The plaintext data encryption key is zeroed after use. Later verification unwraps the KMS-wrapped key, decrypts the bundle in memory, and discards plaintext after the platform lookup.
+
+## In-Enclave Verification
+
+During payment verification, the enclave performs:
+
+```text
+1. KMS unwrap bundle key.
+2. AES-GCM decrypt credential bundle.
+3. Check keccak256(decryptedPayeeId) against the intent payee hash.
+4. Query the payment platform with the seller credential material.
+5. Normalize the payment into method, payee, amount, currency, timestamp, and payment id.
+6. Run UnifiedPaymentVerifier checks.
+7. Sign the EIP-712 PaymentAttestation.
+```
+
+The key binding is:
+
+```text
+keccak256(decryptedPayeeId) == intent.payeeDetails
+```
+
+This binds the decrypted credential to the seller identity in the intent.
+
+## Verifier Checks
+
+| Check | Requirement |
+|---|---|
+| Payment method | Observed platform hash matches `intent.paymentMethod`. |
+| Fiat currency | Observed currency hash matches `intent.fiatCurrency`. |
+| Payee | Decrypted payee hash matches `intent.payeeDetails`. |
+| Timestamp | Payment timestamp plus policy buffer is greater than or equal to intent timestamp. |
+| Intent hash | Payment evidence is bound to the requested intent hash. |
+| Conversion rate | Intent conversion rate is positive. |
+| Amount | Observed payment amount is positive. |
+
+Release amount:
+
+```text
+min(paymentAmount * 10^18 * 10^4 / conversionRate, intentAmount)
+```
+
+`paymentAmount` is in fiat minor units. The `10^4` factor adjusts fiat cents into 6-decimal USDC units.
+
+## Supported Credential Types
+
+| Platform | Credential material | Payee identifier |
+|---|---|---|
+| `venmo` | Session cookie bundle and request headers. | Venmo account id. |
+| `cashapp` | Session cookie bundle, headers, and request payload hints. | Cashtag without leading `$`. |
+| `wise` | Personal API token, profile id, balance id, and currency. | Wise multi-currency-account recipient id. |
+| `paypal` | Gmail OAuth mailbox evidence for PayPal receiver emails. | Seller PayPal email address. |
+
+## Failure Semantics
+
+| Failure | Meaning |
+|---|---|
+| Nitro verification fails | The client must not encrypt credentials to that enclave. |
+| Upload decrypt fails | The ciphertext was not sealed to the current enclave upload key or failed authentication. |
+| Upload binding fails | The payload is stale, replayed, or bound to a different key. |
+| Credential validation fails | The credential does not prove live access to the claimed payment account. |
+| Bundle decrypt fails | The encrypted bundle has been corrupted, tampered with, or wrapped for incompatible KMS context. |
+| Payee hash check fails | The decrypted credential does not belong to the intent payee. |
+| Platform lookup fails | The enclave cannot prove the payment from the available seller-side data. |
+| Verifier check fails | The observed payment does not satisfy the intent. |

--- a/protocol/v3/smart-contracts.md
+++ b/protocol/v3/smart-contracts.md
@@ -24,7 +24,7 @@ This page summarizes the V3 on-chain contracts and links to detailed pages for e
     - Emits `IntentFulfilled`.
 
 ### UnifiedPaymentVerifier
-- Purpose: canonical on-chain verifier for off-chain attestations.
+- Purpose: canonical on-chain verifier for off-chain attestations from buyer zkTLS and Seller Automated Release.
 - V3 uses `UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94`).
 - Typed data
   - Type: `PaymentAttestation(bytes32 intentHash,uint256 releaseAmount,bytes32 dataHash)`
@@ -35,6 +35,7 @@ This page summarizes the V3 on-chain contracts and links to detailed pages for e
   - `dataHash`: hash of the `data` blob.
   - `signatures[]`: witness signatures checked by `AttestationVerifier`.
   - `data`: ABI-encoded `(PaymentDetails, IntentSnapshot)`.
+  - `metadata`: optional attribution bytes. Current service responses encode `buyer-zktls` or `seller-tee`; this field is not signed or digested.
     - `PaymentDetails`:
       - `method`: bytes32 (payment method, e.g., keccak256("venmo"))
       - `payeeId`: bytes32 (hashed off-chain recipient id)

--- a/protocol/v3/smart-contracts/unified-payment-verifier.md
+++ b/protocol/v3/smart-contracts/unified-payment-verifier.md
@@ -4,7 +4,7 @@ title: Unified Payment Verifier
 
 ## Overview
 
-`UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` on Base) is the production verifier for V3 contracts. It verifies standardized off‑chain attestations produced by the Attestation Service. It validates EIP‑712 signatures via a pluggable `AttestationVerifier`, enforces snapshot consistency with on‑chain intent state, prevents replay via nullifiers, and caps the release amount to the signaled intent amount.
+`UnifiedPaymentVerifierV2` (`0x46A58Dc65587D4D7B8198C6A25eEdf5b2535Da94` on Base) is the production verifier for V3 contracts. It verifies standardized off-chain attestations produced by the Attestation Service, whether the source evidence was buyer zkTLS or Seller Automated Release. It validates EIP-712 signatures via a pluggable `AttestationVerifier`, enforces snapshot consistency with on-chain intent state, prevents replay via nullifiers, and caps the release amount to the signaled intent amount.
 
 :::note
 The legacy `UnifiedPaymentVerifier` (`0x16b3e4a3CA36D3A4bCA281767f15C7ADeF4ab163`) is used only by the deprecated V3 Orchestrator. New intents use `UnifiedPaymentVerifierV2` exclusively.
@@ -29,7 +29,7 @@ struct PaymentAttestation {
   bytes32 dataHash;        // keccak256(data)
   bytes[] signatures;      // witness signatures
   bytes data;              // abi.encode(PaymentDetails, IntentSnapshot)
-  bytes metadata;          // optional; not signed
+  bytes metadata;          // optional attribution bytes; not signed
 }
 ```
 
@@ -68,6 +68,8 @@ struct IntentSnapshot {
 6) Cap `releaseAmount` to `intent.amount`.
 
 Returns `PaymentVerificationResult { success, intentHash, releaseAmount }` to the Orchestrator.
+
+`attestation.metadata` is not digested into `dataHash` and is not part of signature verification. Current Attestation Service responses use it as an ABI-encoded source tag: `buyer-zktls` for `/verify/*` and `seller-tee` for `/seller/verify/*`.
 
 ---
 

--- a/protocol/zkp2p-protocol.md
+++ b/protocol/zkp2p-protocol.md
@@ -35,7 +35,7 @@ Below is an illustrative example of the V2 protocol flow using TLSNotary as the 
 ZKP2P V3 is the current production protocol deployed on Base mainnet. It enables permissionless, non‑custodial exchange between off‑chain payments and on‑chain tokens with faster attestations, a simpler on‑chain surface, and clearer integration points.
 
 At a Glance
-- Off‑chain attestation: proofs (e.g., Reclaim/TLSNotary) are validated off‑chain and returned as an EIP‑712 PaymentAttestation.
+- Off‑chain attestation: payment evidence is validated off‑chain and returned as an EIP‑712 PaymentAttestation. V3 supports buyer-generated proofs and the TEE flow used by Seller Automated Release.
 - Unified on‑chain verification: a single `UnifiedPaymentVerifierV2` checks the attestation and enforces protocol rules (snapshot match, nullifiers, capping).
 - Orchestrated intents: `OrchestratorV2` owns the intent lifecycle (signal, cancel, fulfill) and fee routing; `EscrowV2` focuses on deposits and token custody.
 - Oracle rate management: depositors can configure oracle adapters (Chainlink) per currency to auto-adjust minimum conversion rates based on market prices.
@@ -51,7 +51,7 @@ At a Glance
 
 **Perform Off-chain Payment.** Execute an offchain payment in fiat currency through the payment service to the designated seller
 
-**Proof of Payment:** After payment, the buyer generates a proof for the payment data and its authenticity, extracting the following from the payment data:
+**Proof or attestation of payment:** After payment, the protocol verifies the payment data and its authenticity. This can happen through a buyer-generated proof or through Seller Automated Release, where the TEE checks seller-side payment data directly. The verified payment data extracts:
 - Off-ramper's Off-chain payment ID
 - Payment amount
 - Payment timestamp
@@ -68,13 +68,13 @@ At a Glance
 ## The Tech Stack
 **Smart Contract Protocol:** Smart contracts on the Ethereum blockchain enable trustless transactions and manage the logic of the protocol. They are responsible for managing the deposits and intents and the logic for unlocking the escrowed funds.
 
-**Circuits / zkTLS protocol:** Cryptographic primitives that enable generation of private, secure and verifiable credentials to validate payments were made properly in a web2 context. Under the hood, these are proxy-TLS (Reclaim), MPC-TLS (TLSNotary), zkEmail and TEEs
+**Circuits / zkTLS / TEE protocols:** Cryptographic and trusted-computing primitives that validate payments in a web2 context. Buyer flows currently use proxy-TLS (Reclaim) and can support MPC-TLS (TLSNotary) or zkEmail-style proofs. Seller Automated Release uses an AWS Nitro Enclave to handle seller credentials and provider lookups.
 
-**PeerAuth Extension / Appclip:** Browser extension and mobile app clip that enables users to generate privacy-preserving web proofs using any cryptographic primitive (zkTLS, TLSNotary, zkEmail, etc.), similar to OAuth
+**PeerAuth Extension / Appclip:** Browser extension and mobile app clip that enables users to generate privacy-preserving buyer web proofs using primitives such as zkTLS, TLSNotary, and zkEmail, similar to OAuth
 
 **Gating Service:** Backend service that curates and validates intents, enabling sellers to offer liquidity only to users who pass any optional additional verification. Sellers trust the Gating Service to prevent buyers from submitting an intent to their liquidity if they haven't satisfied certain requirements (e.g. user identity). The gating service does not custody or touch funds ever. Conforms to a standard gating service specification as defined by the ZKP2P protocol.
 
-**Attestation Service:** The attestation service is a backend service that validates proofs and returns an EIP-712 PaymentAttestation. It abstracts the complexity of zkTLS proof parsing and verification from the smart contracts. It also enables the protocol to support multiple zkTLS primitives. It will be extended to support TEEs in the future.
+**Attestation Service:** The attestation service validates payment evidence and returns an EIP-712 PaymentAttestation.
 
 **Quoter Backend:** The quoter backend is a backend service that provides the best quotes for the protocol. It indexes all the liquidity in the protocol and provides a REST API for the front end to fetch quotes.
 
@@ -90,3 +90,6 @@ ZKP2P uses [TLSNotary](https://tlsnotary.org/) for certain flows to enable TLS d
 
 ### TLSProxy Libraries
 ZKP2P V2 uses proxy-based TLS protocols such as [Reclaim](https://reclaimprotocol.org/) to verify payments.
+
+### Trusted Execution Environments
+ZKP2P V3 uses AWS Nitro Enclaves for Seller Automated Release. Clients verify the enclave measurement before sending encrypted seller credentials; the enclave performs provider lookups and EIP-712 signing.


### PR DESCRIPTION
## Summary
- Added a new V3 protocol section for Seller Automated Release focused on the Nitro enclave boundary, upload-key verification, JWE sealing, bundle encryption, and in-enclave verification.
- Kept the docs away from endpoint-level API details and centered the narrative on the TEE mechanics and shared `PaymentAttestation` shape.
- Added the `@zkp2p/zkp2p-attestation` npm package as the required Nitro attestation verification flow for client-side upload preparation.
- Updated the surrounding protocol docs to distinguish buyer zkTLS from the seller TEE path and to clarify how `metadata` is used for source attribution.

## Testing
- `yarn build` passed for the Docusaurus site.