### PR TITLE
docs: /verify path now runs inside the Nitro Enclave

### DIFF
--- a/protocol/v3/attestation-service.md
+++ b/protocol/v3/attestation-service.md
@@ -7,12 +7,27 @@ title: Attestation Service
 
 The Attestation Service validates provider proofs off-chain and returns a standardized, signed EIP‑712 PaymentAttestation that the on-chain `UnifiedPaymentVerifier` can verify.
 
-Base URL
+Base URLs
+- Production: `https://attestation-service.zkp2p.xyz` (Base mainnet, runs inside an AWS Nitro Enclave)
 - Local dev: `http://localhost:8080`
 
 Endpoints
 - `GET /verify/supported` — list supported verifiers with their typed data spec.
-- `POST /verify/{platform}/{actionType}` — verify a provider proof and produce a PaymentAttestation.
+- `POST /verify/{platform}/{actionType}` — verify a buyer-generated provider proof and produce a PaymentAttestation.
+- `POST /seller/credentials/{platform}` — upload an encrypted seller credential bundle (Seller Automated Release).
+- `POST /seller/verify/{platform}` — resolve a seller-side payment from a stored credential bundle and produce a PaymentAttestation.
+- `GET /attestation?nonce=...` — return a Nitro NSM attestation document binding the response to the running enclave's code measurement. Used by clients to verify they are talking to the expected enclave before trusting any signed output.
+
+## Trust model
+
+Both the buyer-side `/verify` flow and the seller-side `/seller/*` flow run **end‑to‑end inside an AWS Nitro Enclave**. The same code path that validates a Reclaim/TLSNotary proof, checks the seven payment-detail invariants, and signs the EIP-712 PaymentAttestation executes inside the enclave.
+
+- The EIP-712 signing key is wrapped by an AWS KMS Customer Managed Key whose decrypt policy is gated on the enclave's PCR8 measurement. The key is unwrapped in enclave memory at first use and never leaves the enclave; no operator, AWS, or attacker outside the enclave can extract it.
+- Build artifacts (PCR0/PCR1/PCR2/PCR8) are reproducible from the published source tree. The expected signer address and PCR8 are baked into the enclave image and returned by `/attestation` alongside the NSM document.
+- Clients can verify the attestation document and PCR8 match the published values before sending any sensitive material or trusting any signed PaymentAttestation. Reference verifier: [`@zkp2p/zkp2p-attestation`](https://www.npmjs.com/package/@zkp2p/zkp2p-attestation).
+- On-chain, the enclave's signer is registered as a witness on `MultiAttestationVerifier`. Signatures from any other key are rejected at `fulfillIntent`.
+
+The previous (legacy) deployment ran the same code on commodity infrastructure with the signing key held in plaintext environment variables; that deployment is sunsetted and the canonical hostname now points at the enclave.
 
 `POST /verify/\{platform\}/\{actionType\}`
 Request body (shape)

--- a/protocol/v3/overview.md
+++ b/protocol/v3/overview.md
@@ -38,6 +38,7 @@ ZKP2P V3 is the current production protocol. It enables faster, more flexible, a
 7) Fulfill (on-chain): call `OrchestratorV2.fulfillIntent({ paymentProof: abi.encode(PaymentAttestation), intentHash, ... })`. Orchestrator routes to `UnifiedPaymentVerifierV2` to check the attestation, then unlocks and transfers tokens.
 
 ### Trust model
+- TEE-hosted Attestation Service: both the buyer-side `/verify` path and the seller-side Seller Automated Release path run inside an AWS Nitro Enclave. The EIP-712 signing key is KMS-wrapped and PCR8-gated, so it can only be unwrapped by an enclave running the published code measurement; no operator can extract it. Clients can verify the running enclave via `GET /attestation?nonce=...` before trusting any signed output (reference verifier: `@zkp2p/zkp2p-attestation`).
 - Off-chain witnesses: Attestation Service signatures are verified on-chain by `AttestationVerifier` (e.g., `SimpleAttestationVerifier` with a witness key). Witness rotation is on-chain governed.
 - Intent integrity: snapshot values in the attestation are checked against on-chain intent state; nullifiers prevent double-spend; release amount is capped to the signaled amount.
 - Oracle adapter safety: oracle adapters are view-only (no state mutation). Staleness checks ensure stale data is rejected. Oracle rates can only raise the floor, never lower it below the fixed rate.

--- a/protocol/zkp2p-protocol.md
+++ b/protocol/zkp2p-protocol.md
@@ -68,13 +68,13 @@ At a Glance
 ## The Tech Stack
 **Smart Contract Protocol:** Smart contracts on the Ethereum blockchain enable trustless transactions and manage the logic of the protocol. They are responsible for managing the deposits and intents and the logic for unlocking the escrowed funds.
 
-**Circuits / zkTLS / TEE protocols:** Cryptographic and trusted-computing primitives that validate payments in a web2 context. Buyer flows currently use proxy-TLS (Reclaim) and can support MPC-TLS (TLSNotary) or zkEmail-style proofs. Seller Automated Release uses an AWS Nitro Enclave to handle seller credentials and provider lookups.
+**Circuits / zkTLS / TEE protocols:** Cryptographic and trusted-computing primitives that validate payments in a web2 context. Buyer flows currently use proxy-TLS (Reclaim) and can support MPC-TLS (TLSNotary) or zkEmail-style proofs. Both the buyer-side `/verify` path and Seller Automated Release run end-to-end inside an AWS Nitro Enclave: the enclave validates the payment evidence, applies the seven on-chain invariants, and signs the EIP-712 PaymentAttestation. The signing key is KMS-wrapped and only unwrappable by an enclave running the published code measurement.
 
 **PeerAuth Extension / Appclip:** Browser extension and mobile app clip that enables users to generate privacy-preserving buyer web proofs using primitives such as zkTLS, TLSNotary, and zkEmail, similar to OAuth
 
 **Gating Service:** Backend service that curates and validates intents, enabling sellers to offer liquidity only to users who pass any optional additional verification. Sellers trust the Gating Service to prevent buyers from submitting an intent to their liquidity if they haven't satisfied certain requirements (e.g. user identity). The gating service does not custody or touch funds ever. Conforms to a standard gating service specification as defined by the ZKP2P protocol.
 
-**Attestation Service:** The attestation service validates payment evidence and returns an EIP-712 PaymentAttestation.
+**Attestation Service:** The attestation service validates payment evidence and returns an EIP-712 PaymentAttestation. It runs inside an AWS Nitro Enclave for both buyer (`/verify`) and seller (Seller Automated Release) flows, with the EIP-712 signing key KMS-wrapped and PCR8-gated to the enclave. Clients can verify the running enclave via the `/attestation` endpoint before trusting any signed output.
 
 **Quoter Backend:** The quoter backend is a backend service that provides the best quotes for the protocol. It indexes all the liquidity in the protocol and provides a REST API for the front end to fetch quotes.
 
@@ -92,4 +92,4 @@ ZKP2P uses [TLSNotary](https://tlsnotary.org/) for certain flows to enable TLS d
 ZKP2P V2 uses proxy-based TLS protocols such as [Reclaim](https://reclaimprotocol.org/) to verify payments.
 
 ### Trusted Execution Environments
-ZKP2P V3 uses AWS Nitro Enclaves for Seller Automated Release. Clients verify the enclave measurement before sending encrypted seller credentials; the enclave performs provider lookups and EIP-712 signing.
+ZKP2P V3 runs the Attestation Service inside an AWS Nitro Enclave for both buyer-side proof verification (`/verify`) and Seller Automated Release. The EIP-712 signing key is wrapped by an AWS KMS key whose decrypt policy is gated on the enclave's PCR8 measurement, so the key can only be unwrapped by an enclave running the published code. Clients can verify the running enclave's measurement via `GET /attestation?nonce=...` (which returns an AWS-signed NSM attestation document) before trusting any signed PaymentAttestation. Reference verifier: [`@zkp2p/zkp2p-attestation`](https://www.npmjs.com/package/@zkp2p/zkp2p-attestation).


### PR DESCRIPTION
## Summary

- Cut over the canonical attestation service hostname (`attestation-service.zkp2p.xyz`) from the legacy Railway deployment to the AWS Nitro Enclave today (~0 downtime, signer pre-registered as a `MultiAttestationVerifier` witness).
- Updates the docs to reflect that **both** the buyer-side `/verify` flow and the seller-side `/seller/*` flow now run inside the TEE — previously only Seller Automated Release was described as TEE-hosted.
- Documents the externally verifiable trust model (KMS-wrapped + PCR8-gated signing key, NSM attestation document via `/attestation`, reference verifier `@zkp2p/zkp2p-attestation`).

## Files

- `protocol/v3/attestation-service.md` — prod base URL, full endpoint list (`/seller/*`, `/attestation`), new "Trust model" section.
- `protocol/v3/overview.md` — TEE bullet at the top of the Trust model section.
- `protocol/zkp2p-protocol.md` — tech-stack entries and the "Trusted Execution Environments" section updated for both-flows-in-TEE.

Builds on PR #95 which refined the SAR-side TEE story.

## Test plan

- [ ] `yarn build` succeeds locally
- [ ] Spot-check rendered Trust Model section on the v3 attestation-service page
- [ ] Confirm the `@zkp2p/zkp2p-attestation` link resolves