### PR TITLE
fix: set docs link preview image

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,6 +110,7 @@ const config = {
     /** @type {import('@docusaurus/types').ThemeConfig} */
     ({
 
+      image: 'img/link-preview.png',
       colorMode: {
         defaultMode: 'dark',
         disableSwitch: true,


### PR DESCRIPTION
## Summary
- Sets the docs site social preview image to the existing public `img/link-preview.png` asset.
- Ensures Docusaurus emits Open Graph/Twitter preview metadata for docs.peer.xyz with a resolvable image.
- Keeps the fix scoped to `docusaurus.config.js` with no content or routing changes.

## Why
Linear ZKP2P-2437 reported broken or missing banner images in docs website link previews, likely because the site config did not point preview metadata at a valid public image asset.

## Changes
- Metadata
  - Added `themeConfig.image` in `docusaurus.config.js`.
- Static assets
  - Reused the existing `static/img/link-preview.png` asset.

## Test plan
- `yarn build` - passed; Docusaurus generated static files in `build`.