### PR TITLE
Update SDK docs for npm 0.4.3

### DIFF
--- a/developer/offramp-integration.md
+++ b/developer/offramp-integration.md
@@ -58,9 +58,9 @@ await client.createDeposit({
   amount: 10000000000n, // 10,000 USDC (6 decimals)
   intentAmountRange: { min: 100000n, max: 1000000000n },
   processorNames: ['wise', 'revolut'],
-  depositData: [
-    { wisetag: 'maker' },           // Wise payee details
-    { revolutUsername: 'maker' },   // Revolut payee details
+  payeeData: [
+    { offchainId: 'maker' }, // Wise payee details
+    { offchainId: 'maker' }, // Revolut payee details
   ],
   conversionRates: [
     [{ currency: Currency.USD, conversionRate: '1020000000000000000' }], // 1.02 (18 decimals)
@@ -141,23 +141,23 @@ Supported payment platforms and keys:
 | Luxon | `luxon` |
 | N26 | `n26` |
 
-Each item in `depositData` must line up by index with `processorNames`. If you pass `payeeDetailsHashes` to `createDeposit()`, the SDK uses those hashes directly and skips the curator call. Otherwise the SDK forwards each `depositData` object to curator's public `/v1/makers/create` endpoint to obtain the hashes, so the key names need to match the processor exactly. Either path works without an API key — you can also call `registerPayeeDetails()` standalone to get the hashes ahead of time.
+Each item in `payeeData` must line up by index with `processorNames`. If you pass `payeeDetailsHashes` to `createDeposit()`, the SDK uses those hashes directly and skips the curator call. Otherwise the SDK forwards each `payeeData` object to curator's public `/v1/makers/create` endpoint to obtain the hashes. Either path works without an API key. You can also call `registerPayeeDetails()` standalone to get the hashes ahead of time.
 
-The expected `depositData` shape for each platform is:
+The canonical `payeeData` shape is `{ offchainId, telegramUsername?, metadata? }`. Put the platform-specific identifier in `offchainId`.
 
-| Platform | Key | `depositData` shape | Notes |
+| Platform | Key | `payeeData` example | Notes |
 |----------|-----|---------------------|-------|
-| Wise | `wise` | `{ wisetag: 'your-wisetag' }` | Pass the Wisetag without `@`. Wise uses a manual approval flow in curator. |
-| Venmo | `venmo` | `{ venmoUsername: 'YourVenmoUsername' }` | Do not include `@`. Curator validates the exact Venmo username casing. |
-| Revolut | `revolut` | `{ revolutUsername: 'your-revtag' }` | Do not include `@`. |
-| Cash App | `cashapp` | `{ cashtag: 'yourcashtag' }` | Do not include `$`. |
-| PayPal | `paypal` | `{ paypalMeUsername: 'yourpaypalmeusername' }` | Use the PayPal.me username without the `paypal.me/` prefix. Requires PeerAuth extension v0.4.14+. |
-| Zelle | `zelle` | `{ zelleEmail: 'maker@example.com' }` | Curator expects a lowercase email address. |
-| Monzo | `monzo` | `{ monzoMeUsername: 'your-monzo-me-name' }` | Use the Monzo.me username only. |
-| Mercado Pago | `mercadopago` | `{ cvu: '0000003100064367123868' }` | CVU must be a valid 22-digit Mercado Pago / bank CVU. |
-| Chime | `chime` | `{ chimesign: '$yourchimesign' }` | Include the leading `$`. Curator expects the value in lowercase. |
-| Luxon | `luxon` | `{ luxonUsername: 'maker@example.com' }` | Use a lowercase Luxon email address. |
-| N26 | `n26` | `{ iban: 'DE89370400440532013000' }` | Pass a valid IBAN with spaces removed. |
+| Wise | `wise` | `{ offchainId: 'your-wisetag' }` | Pass the Wisetag without `@`. Wise uses a manual approval flow in curator. |
+| Venmo | `venmo` | `{ offchainId: 'YourVenmoUsername' }` | Do not include `@`. Curator validates the exact Venmo username casing. |
+| Revolut | `revolut` | `{ offchainId: 'your-revtag' }` | Do not include `@`. |
+| Cash App | `cashapp` | `{ offchainId: 'yourcashtag' }` | Do not include `$`. |
+| PayPal | `paypal` | `{ offchainId: 'yourpaypalmeusername' }` | Use the PayPal.me username without the `paypal.me/` prefix. Requires PeerAuth extension v0.4.14+. |
+| Zelle | `zelle` | `{ offchainId: 'maker@example.com' }` | Curator expects a lowercase email address. |
+| Monzo | `monzo` | `{ offchainId: 'your-monzo-me-name' }` | Use the Monzo.me username only. |
+| Mercado Pago | `mercadopago` | `{ offchainId: '0000003100064367123868' }` | CVU must be a valid 22-digit Mercado Pago / bank CVU. |
+| Chime | `chime` | `{ offchainId: '$yourchimesign' }` | Include the leading `$`. Curator expects the value in lowercase. |
+| Luxon | `luxon` | `{ offchainId: 'maker@example.com' }` | Use a lowercase Luxon email address. |
+| N26 | `n26` | `{ offchainId: 'DE89370400440532013000' }` | Pass a valid IBAN with spaces removed. |
 
 ```ts
 import { getPaymentMethodsCatalog, PLATFORM_METADATA, PAYMENT_PLATFORMS } from '@zkp2p/sdk';
@@ -272,7 +272,7 @@ function DepositManager({ client }) {
       amount: 10000000000n,
       intentAmountRange: { min: 100000n, max: 1000000000n },
       processorNames: ['wise'],
-      depositData: [{ email: 'maker@example.com' }],
+      payeeData: [{ offchainId: 'maker@example.com' }],
       conversionRates: [[{ currency: 'USD', conversionRate: '1020000000000000000' }]],
     });
     console.log('Created deposit:', result.hash);

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -25,7 +25,7 @@ Create a client with `new Zkp2pClient(opts)`.
 | `runtimeEnv` | No | Runtime environment: `production`, `preproduction`, or `staging`. Defaults to `production` |
 | `indexerUrl` | No | Override for the indexer GraphQL endpoint |
 | `baseApiUrl` | No | Override for ZKP2P service APIs |
-| `apiKey` | No | Optional curator API key — not required for any method. When provided, some responses are enriched (e.g. `getQuote` returns maker `depositData`) |
+| `apiKey` | No | Optional curator API key — not required to get started. When provided, it enables auto-fetching `signalIntent()` gating signatures and enriches authenticated quote responses with maker `payeeData` |
 | `authorizationToken` | No | Optional bearer token for hybrid authentication |
 | `getAuthorizationToken` | No | Async token provider for long-lived clients |
 | `indexerApiKey` | No | Optional `x-api-key` header for indexer proxy authentication |
@@ -41,7 +41,11 @@ const client = new Zkp2pClient({
 ```
 
 :::info No API key required
-All SDK methods work without `apiKey` or `authorizationToken`. Auth credentials are optional and only affect response richness. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
+Most public SDK methods work without `apiKey` or `authorizationToken`. Auth credentials are optional for normal deposit, quote, and intent flows and mostly affect response richness. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
+:::
+
+:::note Runtime requirements
+The published `0.4.3` package declares `node >= 22` for Node runtimes and `viem ^2.37.3` as a peer dependency.
 :::
 
 ## Prepared transactions
@@ -57,7 +61,7 @@ const prepared = await client.signalIntent.prepare({
   amount: 100_000000n,
   toAddress: '0xYourRecipientAddress',
   processorName: 'wise',
-  payeeDetails: '0xPayeeHash',
+  payeeDetails: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
   fiatCurrencyCode: 'USD',
   conversionRate: 1_020000000000000000n,
 });
@@ -77,7 +81,7 @@ const { depositDetails, prepared } = await client.prepareCreateDeposit({
   amount: 1_000_000000n,
   intentAmountRange: { min: 10_000000n, max: 500_000000n },
   processorNames: ['wise'],
-  depositData: [{ email: 'maker@example.com' }],
+  payeeData: [{ offchainId: 'maker@example.com' }],
   conversionRates: [[
     { currency: 'USD', conversionRate: '1020000000000000000' },
   ]],
@@ -91,14 +95,15 @@ Use `registerPayeeDetails()` when you want to register payment details first and
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `processorNames` | `string[]` | Payment platforms such as `wise`, `revolut`, or `venmo` |
-| `depositData` | `Array<Record<string, string>>` | Processor-specific payment details in the same order as `processorNames` |
+| `payeeData` | `Array<Record<string, string>>` | Processor-specific payment details in the same order as `processorNames` |
+| `depositData` | `Array<Record<string, string>>` | Deprecated alias for `payeeData` |
 
 ```ts
 const { hashedOnchainIds } = await client.registerPayeeDetails({
   processorNames: ['wise', 'revolut'],
-  depositData: [
-    { email: 'maker@example.com' },
-    { tag: '@maker' },
+  payeeData: [
+    { offchainId: 'maker@example.com' },
+    { offchainId: 'maker' },
   ],
 });
 
@@ -107,9 +112,9 @@ await client.createDeposit({
   amount: 1_000_000000n,
   intentAmountRange: { min: 10_000000n, max: 500_000000n },
   processorNames: ['wise', 'revolut'],
-  depositData: [
-    { email: 'maker@example.com' },
-    { tag: '@maker' },
+  payeeData: [
+    { offchainId: 'maker@example.com' },
+    { offchainId: 'maker' },
   ],
   conversionRates: [
     [{ currency: 'USD', conversionRate: '1020000000000000000' }],
@@ -163,7 +168,7 @@ Fulfills a signaled intent with a payment proof. The SDK handles attestation enc
 | Parameter | Required | Description |
 | --- | --- | --- |
 | `intentHash` | Yes | `0x`-prefixed 32-byte intent hash |
-| `proof` | Yes | Reclaim proof object or JSON string |
+| `proof` | Yes | Reclaim proof object/JSON string or a buyer TEE proof input |
 | `timestampBufferMs` | No | Allowed timestamp variance in milliseconds |
 | `attestationServiceUrl` | No | Override for the attestation service |
 | `orchestratorAddress` | No | Explicit orchestrator override |
@@ -182,12 +187,24 @@ Manual release path for returning reserved funds to the deposit owner when an in
 | `orchestratorAddress` | No | Explicit orchestrator override |
 | `txOverrides` | No | viem transaction overrides |
 
+### Deposit hook controls
+
+The V2 orchestrator lets deposit owners configure hooks around intent signaling.
+
+| Method | Description | Key parameters |
+| --- | --- | --- |
+| `setDepositPreIntentHook()` / `.prepare()` | Set the hook called before an intent is accepted | `depositId`, `preIntentHook`, `escrowAddress?`, `orchestratorAddress?` |
+| `getDepositPreIntentHook()` | Read the configured pre-intent hook | `depositId`, `escrowAddress?`, `orchestratorAddress?` |
+| `setDepositWhitelistHook()` / `.prepare()` | Set the whitelist hook for private orderbook or gated deposits | `depositId`, `whitelistHook`, `escrowAddress?`, `orchestratorAddress?` |
+| `getDepositWhitelistHook()` | Read the configured whitelist hook | `depositId`, `escrowAddress?`, `orchestratorAddress?` |
+| `cleanupOrphanedIntents()` / `.prepare()` | Permissionless cleanup for orphaned V2 intents | `intentHashes`, `escrowAddress?`, `orchestratorAddress?` |
+
 ## Vault and rate-manager operations
 
 At the client layer, vaults are exposed as rate managers. These flows are most relevant when you are delegating deposits or managing shared pricing.
 
 :::note
-`staging` defaults to V2 routing. Several vault, delegation, and oracle-backed pricing features are V2-only, even though the SDK still supports legacy fallback for broader deposit and intent flows.
+The `0.4.x` client routes against EscrowV2 and OrchestratorV2. Pass explicit `escrowAddress` or `orchestratorAddress` only when targeting a configured V2 deployment.
 :::
 
 ### Create a vault
@@ -274,6 +291,7 @@ Use `getQuote(req, opts?)` to fetch available liquidity for a taker flow.
 | `includeNearbyQuotes` | No | Include nearby suggestions when no exact quote is available |
 | `nearbySearchRange` | No | Max percent deviation for nearby quote search |
 | `nearbyQuotesCount` | No | Number of nearby suggestions above and below |
+| `includePrivateOrderbooks` | No | Include whitelist-gated private orderbook deposits scoped to the requesting user |
 
 The response includes:
 
@@ -320,6 +338,7 @@ Use `getQuotesBestByPlatform(req, opts?)` when you want the single best quote pe
 The response shape mirrors `getQuote` but is keyed by platform:
 
 - `responseObject.platformQuotes`: array of `{ platform, bestQuote }` entries
+- `responseObject.quoteExpiresAt`: quote expiration timestamp
 - Each `bestQuote` carries the same `referrerFeeAmount` / display fields as `getQuote` when a `referrerFeeConfig` is supplied
 
 ```ts
@@ -356,22 +375,30 @@ The response object includes:
 
 ## Seller Automated Release
 
-Use these methods to upload seller credentials, inspect credential status, and verify seller payments for automated release flows.
-
-:::info Authentication
-`uploadSellerCredential()` and `getSellerCredentialStatus()` require the client to be initialized with `apiKey` or `authorizationToken`.
-:::
+Use these methods to upload seller credentials, inspect credential status, and verify seller payments for automated release flows. Supported seller platforms are `venmo`, `cashapp`, `wise`, and `paypal`.
 
 ### `uploadSellerCredential()`
 
-Use `uploadSellerCredential(params, opts?)` to create a signed credential bundle via the attestation service and store it on the maker through curator. Returns `CuratorSellerCredentialUploadResponse`.
+Use `uploadSellerCredential(params, opts?)` to create a signed credential bundle through the attestation service and store the public credential status in curator. Returns `CuratorSellerCredentialUploadResponse`.
+
+For registered payee platforms (`venmo`, `cashapp`, and `paypal`), pass the seller identity plus platform-specific session material:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `makerId` | Yes | Maker identifier |
-| `platform` | Yes | Seller payment platform: `venmo`, `cashapp`, or `wise` |
-| `payeeId` | Yes | Payee identifier for the seller account |
-| `sessionMaterial` | Yes | Platform-specific session material: `VenmoSessionMaterial`, `CashAppSessionMaterial`, or `WiseSessionMaterial` |
+| `platform` | Yes | `venmo`, `cashapp`, or `paypal` |
+| `offchainId` | Yes | Stable seller identity used for payee registration |
+| `payeeId` | Yes | Platform payee identifier |
+| `telegramUsername` | No | Optional seller Telegram username |
+| `metadata` | No | Optional curator metadata |
+| `sessionMaterial` | Yes | Platform-specific session material |
+
+For Wise, pass only the platform and Wise session material. The enclave derives the payee hash from the submitted token:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `platform` | Yes | `wise` |
+| `sessionMaterial.apiToken` | Yes | Wise Personal API Token |
+| `sessionMaterial.profileId` | No | Wise profile identifier. If omitted and multiple profiles exist, handle the profile-selection response |
 
 Optional `opts` fields:
 
@@ -380,6 +407,7 @@ Optional `opts` fields:
 | `baseApiUrl` | No | Override for the curator base API URL |
 | `attestationServiceUrl` | No | Override for the attestation service used to sign the credential bundle |
 | `timeoutMs` | No | Request timeout in milliseconds |
+| `attestationRuntime` | No | Runtime overrides for `fetch`, `subtle`, or `getRandomValues` |
 
 `VenmoSessionMaterial`
 
@@ -405,9 +433,15 @@ Optional `opts` fields:
 | Field | Required | Description |
 | --- | --- | --- |
 | `apiToken` | Yes | Wise API token |
-| `profileId` | Yes | Wise profile identifier |
-| `balanceId` | Yes | Wise balance identifier |
-| `currency` | Yes | Wise balance currency code |
+| `profileId` | No | Wise profile identifier |
+
+`PayPalSessionMaterial`
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `payeeEmail` | Yes | PayPal seller email |
+| `forwardingBaseMailbox` | Yes | Gmail forwarding base mailbox |
+| `forwardingMailboxAlias` | Yes | Per-seller forwarding alias |
 
 ```ts
 import { Zkp2pClient } from '@zkp2p/sdk';
@@ -415,14 +449,13 @@ import { Zkp2pClient } from '@zkp2p/sdk';
 const client = new Zkp2pClient({
   walletClient,
   chainId: 8453,
-  apiKey: 'your-api-key',
 });
 
 const response = await client.uploadSellerCredential(
   {
-    makerId: 'maker_123',
     platform: 'venmo',
-    payeeId: 'payee_123',
+    offchainId: 'peer-seller',
+    payeeId: '123456789',
     sessionMaterial: {
       recipientUsername: 'peer-seller',
       accountId: '123456789',
@@ -436,13 +469,39 @@ const response = await client.uploadSellerCredential(
 );
 ```
 
-### `getSellerCredentialStatus()`
+### `confirmPayPalForwarding()`
 
-Use `getSellerCredentialStatus(params, opts?)` to fetch seller credential status from curator. Returns `CuratorSellerCredentialStatusResponse`.
+Use `confirmPayPalForwarding(params, opts?)` after a PayPal seller has configured Gmail forwarding. The SDK forwards any configured `apiKey` or bearer token to curator.
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `makerId` | Yes | Maker identifier |
+| `payeeDetails` | Yes | Hashed payee details for the PayPal maker |
+| `payeeEmail` | Yes | PayPal seller email |
+| `forwardingInitiatorEmail` | Yes | Gmail account that initiated forwarding |
+
+The package exports `PayPalForwardingConfirmationErrorCode` for UI-specific handling of rejected, expired, missing, or mismatched forwarding confirmations.
+
+### `uploadGoogleOAuthSellerCredential()`
+
+Use `uploadGoogleOAuthSellerCredential(params, opts?)` when curator owns the Google OAuth encryption hop for PayPal or Venmo credentials.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `platform` | Yes | `paypal` or `venmo` |
+| `authorizationCode` | Yes | One-time Google OAuth code |
+| `payeeDetails` | Yes | Hashed payee details |
+| `redirectUri` | Yes | OAuth redirect URI used to obtain the code |
+| `payeeEmail` | PayPal only | PayPal seller email |
+| `accountId` | Venmo only | Venmo account identifier |
+
+### `getSellerCredentialStatus()`
+
+Use `getSellerCredentialStatus(params, opts?)` to fetch public seller credential status from curator. Returns `CuratorSellerCredentialStatusResponse`.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `processorName` | Yes | Seller payment platform: `venmo`, `cashapp`, `wise`, or `paypal` |
+| `payeeDetails` | Yes | Hashed payee details bytes32 |
 
 Optional `opts` fields:
 
@@ -457,12 +516,12 @@ import { Zkp2pClient } from '@zkp2p/sdk';
 const client = new Zkp2pClient({
   walletClient,
   chainId: 8453,
-  apiKey: 'your-api-key',
 });
 
 const response = await client.getSellerCredentialStatus(
   {
-    makerId: 'maker_123',
+    processorName: 'paypal',
+    payeeDetails: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
   },
   { timeoutMs: 10_000 },
 );
@@ -478,7 +537,7 @@ Use `verifySellerPayment(params, opts?)` to verify a seller payment through cura
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `platform` | Yes | Seller payment platform: `venmo`, `cashapp`, or `wise` |
+| `platform` | Yes | Seller payment platform: `venmo`, `cashapp`, `wise`, or `paypal` |
 | `txId` | Yes | Payment transaction identifier to verify |
 | `chainId` | Yes | Chain ID associated with the verification request |
 | `intent` | Yes | `SellerVerifyIntentDetails` payload for the seller payment verification |
@@ -514,6 +573,23 @@ const response = await client.verifySellerPayment(
 );
 ```
 
+## Standalone API and attestation helpers
+
+The package also exports low-level helpers for integrations that call service APIs directly instead of going through `Zkp2pClient`.
+
+| Helper | Purpose |
+| --- | --- |
+| `apiGetOrderbook(params, opts)` | Fetch orderbook entries for a fiat currency, optional platform, sort, limit, chain, and token |
+| `apiGetDepositBundle(params, opts)` | Fetch one deposit with related intents, events, profit snapshots, fund activities, and daily snapshots |
+| `apiValidatePayeeDetails(req, baseApiUrl, timeoutMs?)` | Validate a payee identity before registration |
+| `apiGetPayeeDetails(req, apiKey, baseApiUrl, authToken?, timeoutMs?)` | Resolve curator payee details from a hashed on-chain ID |
+| `apiGetOwnerDeposits(req, apiKey, baseApiUrl, authToken?, timeoutMs?)` | Fetch owner deposits from the service API |
+| `apiRequestIdentityAttestation(payload, attestationServiceUrl, platform, actionType)` | Request a maker identity attestation |
+| `createEncryptedBuyerTeeSessionMaterial(input)` | Encrypt buyer TEE session material for a buyer-payment proof |
+| `apiCreateSellerCredentialBundle(payload, attestationServiceUrl, platform, timeoutMs?, runtime?)` | Create a signed seller credential bundle directly through attestation service |
+
+`apiGetOrderbook()` accepts `{ currency, paymentPlatform?, sortBy?, sortDirection?, limit?, chainId?, token? }`. `apiGetDepositBundle()` accepts `{ depositId, escrowAddress, dailySnapshotLimit? }`.
+
 ## Querying on-chain data
 
 For common read flows, start with the RPC-first methods:
@@ -525,8 +601,15 @@ For common read flows, start with the RPC-first methods:
 - `getIntents()`
 - `getAccountIntents(owner)`
 - `getIntent(intentHash)`
+- `getPvDepositById(depositId)`
+- `getPvDepositsFromIds(ids)`
+- `getPvAccountDeposits(owner)`
+- `getPvAccountIntents(owner)`
+- `getPvIntent(intentHash)`
 - `resolvePayeeHash(depositId, paymentMethodHash)`
 - `getFulfillIntentInputs(intentHash)`
+- `getDepositPreIntentHook(depositId, options?)`
+- `getDepositWhitelistHook(depositId, options?)`
 - `getDeployedAddresses()`
 - `getUsdcAddress()`
 
@@ -578,7 +661,7 @@ Use `client.indexer` when you need historical data, richer filtering, or paginat
 - `query<T>({ query, variables? })` — raw GraphQL
 - `client` — raw `IndexerClient` instance
 
-The package also exports `IndexerRateManagerService` and the standalone helper `fetchFulfillmentAndPayment(client.indexer.client, intentHash)`.
+The package also exports `IndexerRateManagerService` and the standalone helper `fetchIndexerFulfillmentAndPayment(client.indexer.client, intentHash)`.
 
 ### Indexer converters
 
@@ -588,7 +671,21 @@ The SDK exports converter helpers for turning indexer payloads into the same `Es
 | --- | --- |
 | `convertIndexerDepositToEscrowView(deposit, chainId, escrowAddress)` | Converts a single indexer deposit (with relations) into an `EscrowDepositView` |
 | `convertDepositsForLiquidity(deposits, chainId, escrowAddress, options?)` | Filters and converts indexer deposits into the active liquidity set used by takers. Pass `{ includePrivateOrderbooks: true }` to also include deposits gated by a non-zero whitelist hook (defaults to `false`, public orderbooks only) |
-| `convertIndexerIntentsToEscrowViews(intents)` | Converts indexer intents into `EscrowIntentView[]` |
+| `convertIndexerIntentsToEscrowViews(intents, depositViewsById)` | Converts indexer intents into `EscrowIntentView[]` |
+
+## Oracle helpers
+
+The SDK exports helper constants and encoders for oracle-backed ARM spread pricing.
+
+| Helper | Purpose |
+| --- | --- |
+| `getSpreadOracleConfig(currency, adapters?)` | Resolve bundled Chainlink-first oracle config for a fiat currency |
+| `encodeSpreadOracleAdapterConfig(config)` | Encode Chainlink adapter config |
+| `encodePythAdapterConfig(config)` | Encode Pyth adapter config |
+| `validateOracleFeedsOnChain(publicClient, pythContract?)` | Return currencies whose bundled feeds are available on-chain |
+| `supportsInlineOracleRateConfig({ escrowAddress? })` | Client method that reports whether the target Escrow ABI accepts inline oracle configs |
+
+Useful constants include `CHAINLINK_ORACLE_ADAPTER`, `PYTH_ORACLE_ADAPTER`, `DEFAULT_ORACLE_MAX_STALENESS_SECONDS`, `CHAINLINK_ORACLE_FEEDS`, `SPREAD_ORACLE_FEEDS`, and `PYTH_ORACLE_FEEDS`.
 
 ## Referrer fees
 
@@ -596,7 +693,8 @@ Use these helpers when you want to validate or normalize referrer fee settings b
 
 | Helper | Purpose |
 | --- | --- |
-| `assertValidReferrerFeeConfig(config, context)` | Throws if the config is invalid for `getQuote` or `signalIntent` |
+| `assertValidReferrerFeeConfig(config, context)` | Throws if the config is invalid for `getQuote`, `getQuotesBestByPlatform`, or `signalIntent` |
+| `isValidReferrerFeeRecipient(value)` | Checks whether a referrer fee recipient is a valid address |
 | `isValidReferrerFeeBps(value)` | Checks whether a BPS value is allowed |
 | `parseReferrerFeeConfig(recipient, feeBpsValue)` | Builds a `ReferrerFeeConfig` from loosely typed input |
 | `referrerFeeConfigToPreciseUnits(config)` | Converts the fee config into precise units for on-chain use |

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -8,7 +8,7 @@ slug: /sdk
 
 ## What this does
 
-`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, and embed the Peer extension onramp. The current npm release is `0.3.0` and is published under the MIT license.
+`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, embed the Peer extension onramp, and integrate seller automated release. The current npm release is `0.4.3` and is published under the MIT license.
 
 ## Who is this for?
 
@@ -46,14 +46,15 @@ bun add react
 ```
 
 :::note
-`viem` is a peer dependency. `react >= 16.8.0` is an optional peer dependency that is only required for `@zkp2p/sdk/react`.
+`viem ^2.37.3` is a peer dependency. `react >= 16.8.0` is an optional peer dependency that is only required for `@zkp2p/sdk/react`. For Node runtimes, the published package declares `node >= 22`.
 :::
 
 ## Architecture
 
-The SDK is built around RPC-first reads and contract-safe write helpers.
+The SDK is built around RPC-first reads, V2 contract routing, and contract-safe write helpers.
 
 - Common reads such as `getDeposits()`, `getDeposit()`, `getIntents()`, and `getIntent()` use ProtocolViewer and on-chain state first, which helps avoid indexer lag for core flows.
+- Contract routing targets the EscrowV2/OrchestratorV2 stack. Legacy V1 escrow/orchestrator fallbacks are not part of the `0.4.x` client routing surface.
 - Advanced history and filtering live behind `client.indexer.*`, which gives you GraphQL-backed access to richer search, pagination, and fulfillment records.
 - Write methods are split between deposit management, intent operations, and vault/rate-manager flows, with prepared-transaction support for relayers and smart accounts.
 
@@ -64,6 +65,8 @@ The SDK is built around RPC-first reads and contract-safe write helpers.
 | `Zkp2pClient` | The canonical SDK client for reads, writes, and API-backed flows | [Client Reference](/developer/sdk/client-reference) |
 | `peerExtensionSdk` | Peer extension detection, connection, and onramp deeplink helpers | [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) |
 | `client.indexer` | Advanced deposit, intent, and fulfillment queries | [Client Reference](/developer/sdk/client-reference#indexer) |
+| Seller automated release | Seller credential upload, PayPal forwarding confirmation, OAuth credential upload, status, and payment verification helpers | [Client Reference](/developer/sdk/client-reference#seller-automated-release) |
+| API and attestation helpers | Orderbook, deposit bundle, payee validation, identity attestation, and buyer TEE helpers | [Client Reference](/developer/sdk/client-reference#standalone-api-and-attestation-helpers) |
 | Contract helpers | `getContracts`, `getRateManagerContracts`, `getPaymentMethodsCatalog`, `getGatingServiceAddress` | [Client Reference](/developer/sdk/client-reference#contract-helpers) |
 | Currency and payment helpers | `currencyInfo`, `resolveFiatCurrencyBytes32`, payment-method hash helpers | [Client Reference](/developer/sdk/client-reference#contract-helpers) |
 | Attribution and fee helpers | ERC-8021 helpers and referrer fee validation utilities | [Client Reference](/developer/sdk/client-reference#referrer-fees) |
@@ -107,7 +110,7 @@ The current SDK docs assume Base. Deployment selection is controlled by `chainId
 | --- | --- | --- | --- |
 | Base production | `8453` | `production` | Default customer-facing deployment |
 | Base preproduction | `8453` | `preproduction` | Production contracts with preproduction services |
-| Base staging | `8453` | `staging` | Staging services and V2-first routing defaults |
+| Base staging | `8453` | `staging` | Staging services with V2 contract routing |
 
 ## Recommended starting points
 

--- a/developer/sdk/react-hooks.md
+++ b/developer/sdk/react-hooks.md
@@ -24,7 +24,7 @@ pnpm add @zkp2p/sdk viem react
 bun add @zkp2p/sdk viem react
 ```
 
-`react >= 16.8.0` is an optional peer dependency of `@zkp2p/sdk`.
+`viem ^2.37.3` is a peer dependency of the core SDK. `react >= 16.8.0` is an optional peer dependency that is required for `@zkp2p/sdk/react`.
 
 ## Hook pattern
 
@@ -214,10 +214,11 @@ The hooks package re-exports several delegation helpers and types.
 | Export | Purpose |
 | --- | --- |
 | `ZERO_RATE_MANAGER_ID` | Canonical zero vault ID |
+| `VAULT_ZERO_ADDRESS` | Canonical zero vault registry address |
 | `isZeroRateManagerId(value)` | Checks whether a vault ID is the zero ID |
 | `normalizeRateManagerId(value)` | Normalizes a vault ID string |
 | `normalizeRegistry(value)` | Normalizes a registry address string |
-| `getDelegationRoute(client, escrow)` | Returns whether the deposit should use the `legacy` or `v2` delegation path |
+| `getDelegationRoute(client, escrow)` | Returns the V2 delegation route for the target escrow |
 | `classifyDelegationState(currentRateManagerId, currentRegistry, targetRateManagerId, targetRegistry)` | Classifies whether a deposit is delegated here, elsewhere, or not delegated |
 
 Useful exported types:


### PR DESCRIPTION
## Summary

This updates the SDK documentation to match the currently published `@zkp2p/sdk` npm package, version `0.4.3`. The existing docs still described `0.3.0` and had several stale API shapes, especially around payee registration and seller automated release.

## Issue and user impact

Developers using the published package would hit mismatches between the docs and TypeScript declarations. The most visible problems were examples using the deprecated `depositData` alias, seller credential docs that still referenced `makerId`, missing PayPal and Google OAuth credential flows, and missing V2 hook/orderbook/helper exports. That makes copy-paste integration harder and can send integrators toward methods or parameter names that no longer match the package surface.

## Root cause

The SDK docs had not been refreshed after the npm package moved to the `0.4.x` API. The package declarations now expose V2-only routing, canonical `payeeData`, PayPal seller credential support, forwarding confirmation, OAuth credential upload, buyer TEE and identity attestation helpers, orderbook/deposit-bundle helpers, and updated React delegation utilities.

## Fix

The SDK overview now records npm `0.4.3`, `viem ^2.37.3`, Node `>=22`, V2 routing, and the new seller/API helper areas. The client reference now uses `payeeData`, documents deposit hook controls, private orderbook quote fields, seller automated release parameter shapes, PayPal forwarding and OAuth flows, standalone API/attestation helpers, oracle helpers, and updated indexer helper signatures. The React hooks page now documents the current delegation utility exports, and the off-ramp integration guide now uses the canonical `payeeData` shape.

## Validation

I verified the package source of truth with `npm view @zkp2p/sdk version` and the `@zkp2p/sdk@0.4.3` tarball declaration files. I also ran `git diff --check` and `YARN_ENABLE_GLOBAL_CACHE=false YARN_CACHE_FOLDER=/tmp/yarn-cache yarn build`; the Docusaurus build completed successfully. The build emitted only pre-existing environment warnings about stale Browserslist data and Docusaurus being unable to write its update-check config under `/home/ubuntu/.config`.
