### PR TITLE
docs(rn): Document React Native SDK endpoints

### DIFF
--- a/developer-sidebars.js
+++ b/developer-sidebars.js
@@ -15,6 +15,7 @@ module.exports = {
       items: [
         { type: 'doc', id: 'sdk/sdk-client-reference', label: 'Client Reference' },
         { type: 'doc', id: 'sdk/sdk-react-hooks', label: 'React Hooks' },
+        { type: 'doc', id: 'sdk/sdk-react-native', label: 'React Native SDK' },
       ],
     },
   ],

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -44,6 +44,10 @@ const client = new Zkp2pClient({
 Most public SDK methods work without `apiKey` or `authorizationToken`. Auth credentials are optional for normal deposit, quote, and intent flows and mostly affect response richness. `signalIntent()` can auto-fetch its gating signature when you provide `apiKey` or `authorizationToken`; if you do not want the SDK to make that request, pass `gatingServiceSignature` and `signatureExpiration` yourself.
 :::
 
+:::note Service roots
+Set `baseApiUrl` to the service root, for example `https://api.zkp2p.xyz`. Do not append `/v1`, `/v2`, or `/v3`; the SDK appends the current versioned paths internally.
+:::
+
 :::note Runtime requirements
 The published `0.4.3` package declares `node >= 22` for Node runtimes and `viem ^2.37.3` as a peer dependency.
 :::

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -18,6 +18,7 @@ slug: /sdk
 | An app that wants to open the Peer extension onramp | [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) | Covers `peerExtensionSdk` and the extension deeplink flow |
 | A custom taker flow, backend, or internal tool | [Client Reference](/developer/sdk/client-reference) | Covers `Zkp2pClient`, intents, quotes, vaults, helpers, and API-backed flows |
 | A React app | [React Hooks](/developer/sdk/react-hooks) | Covers the `@zkp2p/sdk/react` hook layer for transaction UX |
+| A React Native app | [React Native SDK](/developer/sdk/react-native) | Covers mobile WebView auth, Buyer TEE proofs, taker registration, SAR, and mobile endpoint defaults |
 
 ## Installation
 
@@ -49,6 +50,12 @@ bun add react
 `viem ^2.37.3` is a peer dependency. `react >= 16.8.0` is an optional peer dependency that is only required for `@zkp2p/sdk/react`. For Node runtimes, the published package declares `node >= 22`.
 :::
 
+For React Native, use the mobile package instead:
+
+```bash
+yarn add @zkp2p/zkp2p-react-native-sdk viem react-native-webview react-native-svg @react-native-async-storage/async-storage @react-native-cookies/cookies expo-crypto expo-web-browser
+```
+
 ## Architecture
 
 The SDK is built around RPC-first reads, V2 contract routing, and contract-safe write helpers.
@@ -71,11 +78,13 @@ The SDK is built around RPC-first reads, V2 contract routing, and contract-safe 
 | Currency and payment helpers | `currencyInfo`, `resolveFiatCurrencyBytes32`, payment-method hash helpers | [Client Reference](/developer/sdk/client-reference#contract-helpers) |
 | Attribution and fee helpers | ERC-8021 helpers and referrer fee validation utilities | [Client Reference](/developer/sdk/client-reference#referrer-fees) |
 | React hooks | Transaction-oriented hooks for deposits, intents, and vaults | [React Hooks](/developer/sdk/react-hooks) |
+| React Native SDK | Mobile provider, `useZkp2p()`, Buyer TEE proof preparation, taker registration, and SAR | [React Native SDK](/developer/sdk/react-native) |
 
 ### Entry points
 
 - Import the core SDK from `@zkp2p/sdk`
 - Import hooks from `@zkp2p/sdk/react`
+- Import the mobile provider, hook, and client from `@zkp2p/zkp2p-react-native-sdk`
 
 :::info Naming note
 `OfframpClient` is a re-export alias of `Zkp2pClient`. Both names work, but `Zkp2pClient` is the canonical class name used by the published typings and the docs on this page.
@@ -119,6 +128,7 @@ If you are new to the SDK, use this order:
 1. Read [Offramp Integration](/developer/offramp) or [Onramp Integration](/developer/integrate-zkp2p/integrate-redirect-onramp) for an end-to-end flow.
 2. Use [Client Reference](/developer/sdk/client-reference) to look up concrete methods, request shapes, and helper exports.
 3. Use [React Hooks](/developer/sdk/react-hooks) if you want component-level loading, error, and transaction state.
+4. Use [React Native SDK](/developer/sdk/react-native) for mobile WebView auth, Buyer TEE, identity registration, and SAR.
 
 ## Help?
 

--- a/developer/sdk/react-native.md
+++ b/developer/sdk/react-native.md
@@ -1,0 +1,330 @@
+---
+id: sdk-react-native
+title: React Native SDK
+slug: /sdk/react-native
+---
+
+# React Native SDK
+
+## What this does
+
+`@zkp2p/zkp2p-react-native-sdk` is the mobile SDK for building Peer onramp, proof, taker registration, and seller automated release flows in React Native. The current npm release is `0.2.3` and it wraps `@zkp2p/sdk@0.4.3` for shared contract, API, quote, and fulfillment logic.
+
+Use this package when your app needs to:
+
+- Authenticate users inside mobile WebViews for supported payment platforms.
+- Prepare Buyer TEE payment proofs from encrypted session material.
+- Fulfill V3 intents through the current attestation service endpoints.
+- Register takers with identity attestations.
+- Register makers for Seller Automated Release (SAR).
+
+## Installation
+
+Install the SDK and its React Native peer dependencies:
+
+```bash
+yarn add @zkp2p/zkp2p-react-native-sdk viem react-native-webview react-native-svg @react-native-async-storage/async-storage @react-native-cookies/cookies expo-crypto expo-web-browser
+```
+
+For iOS:
+
+```bash
+cd ios && pod install
+```
+
+The SDK depends internally on `@zkp2p/react-native-webview-intercept`, `@zkp2p/zkp2p-attestation`, `@zkp2p/contracts-v2`, and `@zkp2p/sdk`; host apps do not need to import those packages directly for normal flows.
+
+## Provider setup
+
+Wrap the app with `Zkp2pProvider`. Pass a wallet client when you want full on-chain actions, or omit it for proof-only flows.
+
+```tsx
+import { Zkp2pProvider } from '@zkp2p/zkp2p-react-native-sdk';
+import type { WalletClient } from 'viem';
+
+declare const walletClient: WalletClient;
+declare const secureStorage: {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string) => Promise<void>;
+  del: (key: string) => Promise<void>;
+};
+
+export function App() {
+  return (
+    <Zkp2pProvider
+      walletClient={walletClient}
+      chainId={8453}
+      apiKey="your-api-key"
+      authorizationToken="optional-bearer-token"
+      rpcUrl="https://base-mainnet.g.alchemy.com/v2/your-key"
+      storage={secureStorage}
+    >
+      <YourScreens />
+    </Zkp2pProvider>
+  );
+}
+```
+
+For proof-only mode, omit `walletClient`, `apiKey`, and auth token values. In that mode `useZkp2p().zkp2pClient` is `null`, but WebView auth and proof preparation can still run.
+
+## Endpoint cutover
+
+Pass service roots only. Do not append `/v1`, `/v2`, or `/v3` to `baseApiUrl`; the SDK appends versioned paths internally.
+
+| Option | Production default | Staging override | Used for |
+| --- | --- | --- | --- |
+| `baseApiUrl` | `https://api.zkp2p.xyz` | `https://api-staging.zkp2p.xyz` | Curator API, quotes, intent signing, maker/taker registration |
+| `attestationServiceUrl` | `https://attestation-service.zkp2p.xyz` | `https://attestation-service-staging.zkp2p.xyz` | Buyer TEE and legacy buyer proof verification |
+| `sarAttestationServiceUrl` | `https://attestation-service-preprod.zkp2p.xyz` | `https://attestation-service-staging.zkp2p.xyz` | SAR credential bundle signing and upload |
+| `identityAttestationServiceUrl` | `https://attestation-service-preprod.zkp2p.xyz` | `https://attestation-service-staging.zkp2p.xyz` | Taker identity registration attestations |
+| `witnessUrl` | `https://witness-proxy.zkp2p.xyz` | Custom | Legacy Reclaim-only proof surfaces |
+
+`environment="staging"` selects staging contracts and staging attestation defaults, but it does not rewrite `baseApiUrl`. Pass `baseApiUrl="https://api-staging.zkp2p.xyz"` explicitly when testing against staging API services.
+
+Current service paths used by the SDK:
+
+| Flow | Method and path |
+| --- | --- |
+| Intent gating signature | `POST /v3/intent/sign` |
+| Exact fiat quote | `POST /v2/quote/exact-fiat` |
+| Exact token quote | `POST /v2/quote/exact-token` |
+| Taker registration status | `GET /v2/taker/registration/{processorName}/status` |
+| Taker registration | `POST /v2/taker/registration/{processorName}/register` |
+| Maker registration | `POST /v2/makers/create` |
+| Buyer TEE verification | `POST /buyer/verify/{platform}/{actionType}` |
+| Legacy buyer proof verification | `POST /verify/{platform}/{actionType}` |
+
+The current mobile SDK targets the upgraded V2 escrow/orchestrator contracts only. Remove app overrides that point at legacy escrow hosts, versioned curator roots, or old mobile gnark prover assets.
+
+## Buyer TEE fulfillment
+
+Buyer TEE is the default buyer verification path for supported platforms. The SDK verifies the running enclave, encrypts payment-platform session material to the enclave upload key, sends the encrypted payload to `/buyer/verify/{platform}/{actionType}`, and then passes the returned V3 attestation into `fulfillIntent`.
+
+```tsx
+import { useZkp2p } from '@zkp2p/zkp2p-react-native-sdk';
+
+function BuyerFlow({ intentHash }: { intentHash: `0x${string}` }) {
+  const {
+    initiate,
+    prepareBuyerTeeProof,
+    zkp2pClient,
+    provider,
+    interceptedPayload,
+    metadataList,
+    proofStatus,
+  } = useZkp2p();
+
+  const buy = async () => {
+    if (!zkp2pClient) throw new Error('Wallet client required to fulfill');
+
+    await initiate('venmo', 'transfer_venmo', {
+      initialAction: {
+        enabled: true,
+        paymentDetails: {
+          RECIPIENT_ID: 'seller-venmo-id',
+          AMOUNT: '100.00',
+        },
+      },
+    });
+
+    if (!provider || !interceptedPayload || !metadataList[0]) {
+      throw new Error('Payment metadata unavailable');
+    }
+
+    const proof = await prepareBuyerTeeProof(
+      provider,
+      interceptedPayload,
+      metadataList[0]
+    );
+
+    await zkp2pClient.fulfillIntent({
+      intentHash,
+      proof,
+    });
+  };
+
+  return (
+    <Button
+      title={proofStatus.phase === 'running' ? 'Verifying' : 'Buy'}
+      onPress={buy}
+    />
+  );
+}
+```
+
+`generateProof()` remains available for legacy Reclaim-only surfaces, but new mobile buyer integrations should use `prepareBuyerTeeProof()`.
+
+## Quotes and intents
+
+Create a client through the provider or directly:
+
+```ts
+import { Zkp2pClient } from '@zkp2p/zkp2p-react-native-sdk';
+
+const client = new Zkp2pClient({
+  chainId: 8453,
+  walletClient,
+  apiKey: 'your-api-key',
+  rpcUrl: 'https://base-mainnet.g.alchemy.com/v2/your-key',
+});
+```
+
+Fetch quotes from the V2 quote endpoints:
+
+```ts
+const quote = await client.getQuote({
+  paymentPlatforms: ['venmo', 'wise'],
+  fiatCurrency: 'USD',
+  user: '0xTakerAddress',
+  recipient: '0xRecipientAddress',
+  destinationChainId: 8453,
+  destinationToken: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  amount: '100',
+  isExactFiat: true,
+});
+```
+
+Signal and fulfill intents through the wrapped `@zkp2p/sdk` client:
+
+```ts
+const { txHash } = await client.signalIntent({
+  processorName: 'venmo',
+  depositId: '123',
+  amount: '100000000',
+  payeeDetails: '0x...',
+  toAddress: '0xRecipientAddress',
+  fiatCurrencyCode: 'USD',
+  conversionRate: '1000000000000000000',
+});
+
+await client.fulfillIntent({
+  intentHash: '0xIntentHash',
+  proof,
+});
+```
+
+`walletClient` is required for transaction-sending methods such as `signalIntent()`, `fulfillIntent()`, `createDeposit()`, `withdrawDeposit()`, `cancelIntent()`, and `releaseFundsToPayer()`.
+
+## Taker registration
+
+Some payment processors require taker identity registration. The mobile flow produces an identity attestation through the identity attestation service and posts that attestation to curator. It does not post legacy proof JSON.
+
+```tsx
+import {
+  apiGetTakerRegistrationStatus,
+  apiRegisterTaker,
+  useZkp2p,
+} from '@zkp2p/zkp2p-react-native-sdk';
+
+const baseApiUrl = 'https://api.zkp2p.xyz';
+
+function RegisterTakerButton() {
+  const {
+    authenticate,
+    prepareIdentityAttestation,
+    provider,
+    interceptedPayload,
+    metadataList,
+  } = useZkp2p();
+
+  const register = async () => {
+    const authToken = await getPrivyAccessToken();
+
+    const status = await apiGetTakerRegistrationStatus(
+      'venmo',
+      authToken,
+      baseApiUrl
+    );
+
+    if (!status.responseObject?.registrationRequired) return;
+
+    await authenticate('venmo', 'register_venmo');
+
+    if (!provider || !interceptedPayload || !metadataList[0]) {
+      throw new Error('Identity metadata unavailable');
+    }
+
+    const identity = await prepareIdentityAttestation(
+      provider,
+      interceptedPayload,
+      metadataList[0]
+    );
+
+    await apiRegisterTaker(
+      'venmo',
+      identity.attestation,
+      authToken,
+      baseApiUrl
+    );
+  };
+
+  return <Button title="Register taker" onPress={register} />;
+}
+```
+
+Supported identity registration platforms are `venmo`, `paypal`, and `wise`.
+
+## Seller Automated Release
+
+SAR lets a maker register encrypted seller session material so matching buyer payments can be verified from the seller side. The mobile SDK exposes this through `useZkp2p().sar`.
+
+```tsx
+import { useZkp2p } from '@zkp2p/zkp2p-react-native-sdk';
+
+function RegisterMakerButton() {
+  const { sar } = useZkp2p();
+
+  const register = async () => {
+    if (!sar.isSupported('wise')) return;
+
+    const result = await sar.registerMaker({
+      platform: 'wise',
+      payeeHandle: 'your-wisetag',
+      currency: 'USD',
+    });
+
+    console.log(result.payeeIdHash, result.status);
+  };
+
+  return <Button title="Register maker" onPress={register} />;
+}
+```
+
+Supported SAR platforms are `wise`, `venmo`, `cashapp`, and `paypal`. PayPal registration also requires `payeeEmail`; `googleOAuthEmail` is optional when receipts are forwarded through a different Gmail inbox.
+
+Use `sar.getStatus()`, `sar.revoke()`, `sar.onExpired()`, and `sar.clearAllSessions()` to keep local session state in sync with curator and user sign-out flows.
+
+## Storage and consent
+
+Pass a `storage` adapter when using credential persistence, consent prompts, or SAR. The SDK stores provider consent and credentials under hashed keys and stores SAR seller sessions under platform-specific keys. Use the context helpers to clear data:
+
+```ts
+const {
+  clearAllCredentials,
+  clearAllConsents,
+  clearProviderCredentials,
+  clearProviderConsent,
+  sar,
+} = useZkp2p();
+
+await clearAllCredentials();
+await clearAllConsents();
+await sar.clearAllSessions();
+```
+
+To replace the default proof progress sheet, pass `hideDefaultProofUI` and render from `proofStatus`. Call `cancelProof()` to stop the active proof.
+
+## Troubleshooting
+
+| Problem | Check |
+| --- | --- |
+| API calls include duplicated versions such as `/v2/v2/...` | Pass `baseApiUrl` as a root host only, for example `https://api.zkp2p.xyz`. |
+| Staging contracts work but API calls hit production | `environment="staging"` does not rewrite `baseApiUrl`; pass `https://api-staging.zkp2p.xyz`. |
+| `zkp2pClient` is `null` | The provider is running proof-only mode. Pass a viem `walletClient` for on-chain actions. |
+| Buyer TEE proof fails before upload | Ensure `attestationServiceUrl` points at the root attestation host and that the platform/action pair is supported. |
+| SAR cannot persist session material | Pass a `storage` adapter to `Zkp2pProvider`. |
+| Taker registration is rejected | Use `prepareIdentityAttestation()` and submit `identity.attestation`; do not submit legacy proof JSON. |
+
+## Help?
+
+If you run into issues, join our [Discord](https://discord.gg/4hNVTv2MbH).

--- a/protocol/gating-service.md
+++ b/protocol/gating-service.md
@@ -22,4 +22,4 @@ See [Pre-Intent Hooks](/protocol/v3/smart-contracts/pre-intent-hooks) for detail
 
 ### API Reference
 
-Our current gating service API is hosted at api.peer.xyz
+Our current gating service API is hosted at `https://api.zkp2p.xyz`. SDK clients should pass this as the root `baseApiUrl`; do not append `/v1`, `/v2`, or `/v3`.


### PR DESCRIPTION
## Summary

This PR updates the developer docs for the latest `@zkp2p/zkp2p-react-native-sdk` release and hardcuts the documented service guidance to the current root-host endpoint model.

The docs previously covered the web/extension SDK but did not give mobile integrators a dedicated place to find the React Native package, Buyer TEE flow, mobile attestation defaults, taker registration, or Seller Automated Release APIs. That made it easy for app developers to reuse stale web assumptions, append version prefixes to API roots, or miss the separate mobile attestation defaults now used by the pulled React Native SDK.

The root cause was that the docs had not been updated alongside the React Native SDK's latest main branch. The SDK now targets the upgraded V2 escrow/orchestrator surface, uses root-only curator API hosts, appends current versioned paths internally, routes Buyer TEE verification through `/buyer/verify/{platform}/{actionType}`, and exposes mobile-only identity/SAR flows through `useZkp2p()`.

## Changes

- Added a dedicated React Native SDK page covering installation, provider setup, endpoint defaults, Buyer TEE fulfillment, quotes/intents, taker identity registration, Seller Automated Release, storage/consent, and troubleshooting.
- Linked the new React Native SDK page from the SDK overview and developer sidebar.
- Added a root-only `baseApiUrl` note to the SDK client reference so integrators do not pass `/v1`, `/v2`, or `/v3` suffixed service URLs.
- Updated the gating service host from the stale `api.peer.xyz` reference to `https://api.zkp2p.xyz`.

## Validation

- Pulled `zkp2p-react-native-sdk` to latest `origin/main` (`4cb3147`) and verified npm latest is `0.2.3`.
- Ran `git diff --check`.
- Ran `YARN_CACHE_FOLDER=/tmp/yarn-cache yarn install` after the fresh clone had no Yarn install state.
- Ran `YARN_CACHE_FOLDER=/tmp/yarn-cache yarn build` successfully. Docusaurus only emitted existing browserslist/update-check warnings.
