### PR TITLE
docs: reframe legacy Reclaim references as zkTLS providers / V2 legacy

### DIFF
--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -172,7 +172,7 @@ Fulfills a signaled intent with a payment proof. The SDK handles attestation enc
 | Parameter | Required | Description |
 | --- | --- | --- |
 | `intentHash` | Yes | `0x`-prefixed 32-byte intent hash |
-| `proof` | Yes | Reclaim proof object/JSON string or a buyer TEE proof input |
+| `proof` | Yes | zkTLS proof object/JSON string or a buyer TEE proof input |
 | `timestampBufferMs` | No | Allowed timestamp variance in milliseconds |
 | `attestationServiceUrl` | No | Override for the attestation service |
 | `orchestratorAddress` | No | Explicit orchestrator override |

--- a/protocol/peerauth-extension/zk-tls.md
+++ b/protocol/peerauth-extension/zk-tls.md
@@ -7,7 +7,7 @@ title: zkTLS
 
 ## Overview
 
-At ZKP2P, we make heavy use of zkTLS techniques to prove authenticity of data while preserving user privacy. zkTLS enables us to port any data from the web served through TLS1.2 and TLS1.3 to smart contracts. In particular, there are 2 techniques: TLSNotary (MPC-TLS) and TLSProxy (proxy based approach e.g [Reclaim Protocol](https://reclaimprotocol.org/))
+At ZKP2P, we make heavy use of zkTLS techniques to prove authenticity of data while preserving user privacy. zkTLS enables us to port any data from the web served through TLS1.2 and TLS1.3 to smart contracts. In particular, there are 2 techniques: TLSNotary (MPC-TLS) and TLSProxy (a proxy-based approach using third-party zkTLS proof providers).
 
 ## TLSNotary
 
@@ -68,7 +68,11 @@ To understand TLSNotary, please go through their docs
 
 [TLSN Docs](https://docs.tlsnotary.org/)
 
-### TLSProxy (Reclaim)
+### TLSProxy
+
+:::note
+The proxy-TLS provider flow described below was used in the legacy V2 protocol. It is retained here for historical context. The current V3 production flow validates payments off-chain via the Attestation Service (Buyer TEE Verification and Seller Automated Release).
+:::
 
 Unlike TLSNotary, the proxy approach relies on the Notary being in between the Prover (buyer) and the Server. Privacy is still preserved as only encrypted ciphertext is sent from the Prover to the Notary (Witness Proxy), and the prover is the only party that holds the symmetric TLS keys. This approach is significantly more efficient as it removes the need to generate the TLS session keys using 2PC Garbled Circuits.
 
@@ -76,10 +80,6 @@ However, it is not as censorship resistant as the MPC-TLS approach due to the in
 
 Additionally, there is a possibility of a Prover MITM (man-in-the-middle) attack to change packets enroute if they are able to gain access to the port in the datacenter where the Notary (Proxy) is hosted. This is because the Prover holds the TLS keys.
 
-Despite this, we believe the proxy based approach is most production ready and can scale up to a certain dollar amount of value before we need to migrate to TLSNotary. Reclaim protocol has undergone multiple audits.
+The proxy-based zkTLS proof providers used in V2 had undergone multiple independent audits, which is why the approach was considered production ready at the time.
 
 Additionally, ZKP2P is built to be generic so we can plug in any primitive as they become mature.
-
-For more details, please check out the Reclaim docs:
-
-[Reclaim Protocol Docs](https://docs.reclaimprotocol.org/)

--- a/protocol/v2/smart-contracts/deployments.md
+++ b/protocol/v2/smart-contracts/deployments.md
@@ -3,6 +3,10 @@ id: v2-deployments
 title: Deployments
 ---
 
+:::note
+These V2 verifier contracts are legacy. The on-chain proxy-TLS (zkTLS) verifiers listed below are no longer the active verification path — they are kept read-only for historical reference. The current production flow validates payments off-chain via the V3 Attestation Service (Buyer TEE Verification and Seller Automated Release), checked on-chain by `UnifiedPaymentVerifierV2`. See the [Attestation Service](../../v3/attestation-service.md) docs.
+:::
+
 ## Base
 
 <table>

--- a/protocol/v2/smart-contracts/ipaymentverifier.md
+++ b/protocol/v2/smart-contracts/ipaymentverifier.md
@@ -22,7 +22,7 @@ struct VerifyPaymentData {
 }
 ```
 
-Additional data may include mail server key hash if using zkEmail, notary public key for TLSNotary or witness proxy for TLSProxy (Reclaim)
+Additional data may include mail server key hash if using zkEmail, notary public key for TLSNotary or witness proxy for proxy-TLS (zkTLS) providers
 
 ### External Functions
 

--- a/protocol/v3/migration.md
+++ b/protocol/v3/migration.md
@@ -9,7 +9,7 @@ How to move from the V2 proof flow to the V3 attestation flow with minimal chang
 
 ### Key differences
 - Off-chain verification
-  - V2: proof JSON (e.g., Reclaim/TLSN) was parsed/validated on-chain by per‑platform verifier contracts.
+  - V2: zkTLS proof JSON (proxy-TLS or TLSNotary) was parsed/validated on-chain by per‑platform verifier contracts.
   - V3: proofs are validated off-chain by the Attestation Service, which emits a signed `PaymentAttestation` verified by a single `UnifiedPaymentVerifierV2` on-chain.
 - On-chain interface
   - V2: multiple verifiers per platform with heterogeneous calldata.

--- a/protocol/zkp2p-protocol.md
+++ b/protocol/zkp2p-protocol.md
@@ -89,7 +89,7 @@ ZKP2P builds upon the 0xParc/PSE [zkEmail](https://prove.email/) libraries to en
 ZKP2P uses [TLSNotary](https://tlsnotary.org/) for certain flows to enable TLS data to be used on-chain in a privacy-preserving way.
 
 ### TLSProxy Libraries
-ZKP2P V2 uses proxy-based TLS protocols such as [Reclaim](https://reclaimprotocol.org/) to verify payments.
+The legacy V2 protocol used proxy-based zkTLS proof providers to verify payments on-chain. This flow is superseded in V3 by the off-chain Attestation Service (Buyer TEE Verification and Seller Automated Release); the on-chain V2 proxy-TLS verifiers remain deployed only for historical reference.
 
 ### Trusted Execution Environments
 ZKP2P V3 runs the Attestation Service inside an AWS Nitro Enclave for buyer proof verification, Buyer TEE Verification, and Seller Automated Release. The EIP-712 signing key is wrapped by an AWS KMS key whose decrypt policy is gated on the enclave's PCR8 measurement, so the key can only be unwrapped by an enclave running the published code. Clients can verify the running enclave's measurement via `GET /attestation?nonce=...` (which returns an AWS-signed NSM attestation document) before trusting any signed PaymentAttestation or encrypting session material to its upload key. Reference verifier: [`@zkp2p/zkp2p-attestation`](https://www.npmjs.com/package/@zkp2p/zkp2p-attestation).


### PR DESCRIPTION
## Summary

Part of the migration to the buyer-TEE flow. Reframes lingering legacy **Reclaim Protocol** references so the docs reflect that the current production verification path is the **off-chain V3 Attestation Service** (Buyer TEE Verification + Seller Automated Release), and the **V2 on-chain proxy-TLS (Reclaim) verifiers are legacy / read-only**.

No historically-accurate V2 content was deleted — it is reframed as legacy. V2 verifier contract names and addresses are kept verbatim for historical reference.

## Changes

- **`protocol/zkp2p-protocol.md`** — "TLSProxy Libraries" section: replaced the Reclaim-specific line (and its third-party link) with generic "zkTLS proof providers" language, noting V2 proxy-TLS verifiers are superseded by the V3 Attestation Service.
- **`protocol/v3/migration.md`** — clarified the V2→V3 key-difference example: "Reclaim/TLSN" → "zkTLS proof JSON (proxy-TLS or TLSNotary)".
- **`protocol/peerauth-extension/zk-tls.md`** — generalized the overview to "third-party zkTLS proof providers"; renamed the "TLSProxy (Reclaim)" subsection to "TLSProxy", marked it historical/legacy-V2 with a note pointing at the V3 Attestation Service, and removed the dead third-party Reclaim docs link.
- **`protocol/v2/smart-contracts/deployments.md`** — added a note that the V2 verifier contracts are legacy/read-only and superseded by the V3 Attestation Service; addresses kept for historical reference.
- **`protocol/v2/smart-contracts/ipaymentverifier.md`** — "TLSProxy (Reclaim)" → "proxy-TLS (zkTLS) providers".
- **`developer/sdk/client-reference.md`** — `fulfillIntent` `proof` param: "Reclaim proof object" → "zkTLS proof object".

## Verification

`yarn build` passes — static site generated with no broken-link errors (the new relative link in `deployments.md` resolves).