### PR TITLE
docs: update SDK docs for npm 0.5.0

### DIFF
--- a/developer/build-your-own-extension.md
+++ b/developer/build-your-own-extension.md
@@ -345,6 +345,8 @@ Before storing, verify the registered payee hash matches the bundle's `payeeIdHa
 
 ## SDK reference for extension builders
 
+All of these ship in `@zkp2p/sdk` `0.5.0` or newer.
+
 | Export | Flow | Use |
 |--------|------|-----|
 | `createEncryptedBuyerTeeSessionMaterial({ platform, actionType, attestationServiceUrl, sessionMaterial })` | Buyer | Encrypt captured session material against the attestation TEE; returns the `encryptedSessionMaterial` string |

--- a/developer/integrate-zkp2p/integrate-redirect-onramp.md
+++ b/developer/integrate-zkp2p/integrate-redirect-onramp.md
@@ -12,7 +12,7 @@ Extension `0.6.0` removes the side panel and the entire deeplink onramp API: `pe
 
 If you are live on the old flow:
 
-- **Migrate to the flow below now.** Your app drives the onramp with `Zkp2pClient`, and the extension is only used as a headless payment capture bridge.
+- **Migrate to the flow below now.** Your app drives the onramp with `Zkp2pClient` on `@zkp2p/sdk@0.5.0+`, and the extension is only used as a headless payment capture bridge.
 - **As a temporary stopgap**, ask your users to pause extension auto-updates so they remain on their installed pre-`0.6.0` version until your migration ships. Treat this strictly as a bridge — unmanaged Chrome installs cannot pin extension versions reliably.
 
 See [Migrating from the pre-0.6.0 deeplink flow](#migrating-from-the-pre-060-deeplink-flow) for a mapping of the old API to the new surface.
@@ -32,7 +32,7 @@ Use this guide if you are building a desktop web app that needs users to verify 
 
 You need:
 
-- `@zkp2p/sdk` installed in your web app
+- `@zkp2p/sdk` `0.5.0` or newer installed in your web app — `0.5.0` is the first release that ships the headless `peerExtensionSdk`; `0.4.x` only exposes the removed deeplink wrapper
 - The Peer extension installed and connected for the current origin
 - A `Zkp2pClient` configured for the chain and runtime
 - An intent your app already created or selected
@@ -484,7 +484,7 @@ See [Build Your Own Extension](/developer/build-your-own-extension) for the full
 
 ## Migrating from the pre-0.6.0 deeplink flow
 
-The pre-`0.6.0` integration opened a Peer-branded side panel that ran the whole onramp. That UI no longer exists — your app now drives the flow and the extension only captures payment confirmation. Mapping the old surface to the new one:
+The pre-`0.6.0` integration opened a Peer-branded side panel that ran the whole onramp. That UI no longer exists — your app now drives the flow and the extension only captures payment confirmation. Start by upgrading to `@zkp2p/sdk` `0.5.0` or newer: the `0.4.x` `peerExtensionSdk` only exposes the removed deeplink API. Then map the old surface to the new one:
 
 | Pre-`0.6.0` | `0.6.0+` |
 |-------------|----------|

--- a/developer/sdk/client-reference.md
+++ b/developer/sdk/client-reference.md
@@ -49,7 +49,7 @@ Set `baseApiUrl` to the service root, for example `https://api.zkp2p.xyz`. Do no
 :::
 
 :::note Runtime requirements
-The published `0.4.3` package declares `node >= 22` for Node runtimes and `viem ^2.37.3` as a peer dependency.
+The published `0.5.0` package declares `node >= 22` for Node runtimes and `viem ^2.37.3` as a peer dependency.
 :::
 
 ## Prepared transactions
@@ -178,7 +178,7 @@ Fulfills a signaled intent with a payment proof. The SDK handles attestation enc
 | `orchestratorAddress` | No | Explicit orchestrator override |
 | `postIntentHookData` | No | Hook payload passed to the orchestrator |
 | `txOverrides` | No | viem transaction overrides |
-| `callbacks` | No | UI lifecycle callbacks such as `onAttestationStart`, `onTxSent`, and `onTxMined` |
+| `callbacks` | No | UI lifecycle callbacks such as `onAttestationStart`, `onAttestationComplete`, `onTxSent`, and `onTxMined` |
 | `precomputedAttestation` | No | Pre-encoded attestation data for advanced flows |
 
 ### `releaseFundsToPayer()` / `releaseFundsToPayer.prepare()`
@@ -208,7 +208,7 @@ The V2 orchestrator lets deposit owners configure hooks around intent signaling.
 At the client layer, vaults are exposed as rate managers. These flows are most relevant when you are delegating deposits or managing shared pricing.
 
 :::note
-The `0.4.x` client routes against EscrowV2 and OrchestratorV2. Pass explicit `escrowAddress` or `orchestratorAddress` only when targeting a configured V2 deployment.
+The `0.5.x` client routes against EscrowV2 and OrchestratorV2. Pass explicit `escrowAddress` or `orchestratorAddress` only when targeting a configured V2 deployment.
 :::
 
 ### Create a vault
@@ -473,6 +473,30 @@ const response = await client.uploadSellerCredential(
 );
 ```
 
+### `uploadSellerCredentialBundle()`
+
+Use `uploadSellerCredentialBundle(params, opts?)` when the encrypted credential bundle was already created elsewhere — typically inside a capture extension via `apiCreateSellerCredentialBundle()` — and you only need to register the payee and store the bundle with curator. This is the page-side half of the [extension Seller Autopilot capture flow](/developer/build-your-own-extension#implementing-the-seller-autopilot-flow). Available from `0.5.0`.
+
+For registered payee platforms (`venmo`, `cashapp`, and `paypal`):
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `platform` | Yes | `venmo`, `cashapp`, or `paypal` |
+| `offchainId` | Yes | Stable seller identity used for payee registration |
+| `bundle` | Yes | Encrypted `SellerCredentialBundle` returned by the capture |
+| `telegramUsername` | No | Optional seller Telegram username |
+| `metadata` | No | Optional curator metadata |
+
+For Wise, pass only `platform: 'wise'` and the `bundle`. Optional `opts` fields are `baseApiUrl` and `timeoutMs`.
+
+```ts
+const response = await client.uploadSellerCredentialBundle({
+  platform: 'venmo',
+  offchainId: capture.offchainId,
+  bundle: capture.credentialBundle,
+});
+```
+
 ### `confirmPayPalForwarding()`
 
 Use `confirmPayPalForwarding(params, opts?)` after a PayPal seller has configured Gmail forwarding. The SDK forwards any configured `apiKey` or bearer token to curator.
@@ -639,8 +663,8 @@ Use `client.indexer` when you need historical data, richer filtering, or paginat
 - `getIntentsByRateManager(rateManagerId, statuses?)`
 - `getIntentByHash(intentHash)`
 - `getExpiredIntents({ now, depositIds, limit? })`
-- `getFulfilledIntentEvents(intentHashes)`
-- `getIntentFulfillmentAmounts(intentHash)`
+- `getFulfilledIntentEvents(intentHashes)` — fulfillment events, including `takerAmountNetFees`
+- `getIntentFulfillmentAmounts(intentHash)` — includes `takerAmountNetFees`, the net USDC the taker received after fees
 - `getFulfillmentAndPayment(intentHash)`
 
 ### Fund activity and snapshots

--- a/developer/sdk/overview.md
+++ b/developer/sdk/overview.md
@@ -8,7 +8,7 @@ slug: /sdk
 
 ## What this does
 
-`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, run Peer extension headless metadata capture, and integrate Seller Autopilot. The current npm release is `0.4.3` and is published under the MIT license.
+`@zkp2p/sdk` is the TypeScript SDK for building with Peer. Use it to manage deposits, signal and fulfill intents, access quote and taker-tier APIs, work with vault and rate-manager flows, run Peer extension headless metadata capture, and integrate Seller Autopilot. The current npm release is `0.5.0` and is published under the MIT license.
 
 ## Who is this for?
 

--- a/developer/sdk/react-native.md
+++ b/developer/sdk/react-native.md
@@ -8,7 +8,7 @@ slug: /sdk/react-native
 
 ## What this does
 
-`@zkp2p/zkp2p-react-native-sdk` is the mobile SDK for building Peer onramp, proof, taker registration, and Seller Autopilot flows in React Native. The current npm release is `0.2.3` and it wraps `@zkp2p/sdk@0.4.3` for shared contract, API, quote, and fulfillment logic.
+`@zkp2p/zkp2p-react-native-sdk` is the mobile SDK for building Peer onramp, proof, taker registration, and Seller Autopilot flows in React Native. The current npm release is `0.4.1` and it wraps `@zkp2p/sdk@0.4.3` for shared contract, API, quote, and fulfillment logic.
 
 Use this package when your app needs to:
 

--- a/static/onramp-llm.md
+++ b/static/onramp-llm.md
@@ -4,7 +4,7 @@ The app owns order UI, payment-row selection, and `fulfillIntent()`. The extensi
 
 ## 1. Initialize the SDK
 
-Use a scoped extension instance and an app-owned `Zkp2pClient`.
+Use a scoped extension instance and an app-owned `Zkp2pClient`. Require `@zkp2p/sdk` `0.5.0` or newer.
 
 ```ts
 import {
@@ -289,7 +289,7 @@ async function verifyBuyerTeePaymentDirectly({
 
 ## Key rules
 
-- Target Peer extension manifest `0.6.0` or newer.
+- Target Peer extension manifest `0.6.0` or newer and `@zkp2p/sdk` `0.5.0` or newer — `0.4.x` only ships the removed deeplink wrapper.
 - Never use `onramp()`, `openSidebar()`, `onIntentFulfilled()`, `onProofComplete()`, or `callbackUrl` — the pre-`0.6.0` deeplink/side-panel API was removed.
 - Use `createPeerExtensionSdk({ window })`.
 - Register `onMetadataMessage()` before `authenticate()`.


### PR DESCRIPTION
## What changed

`@zkp2p/sdk@0.5.0` is now published — it's the release that ships the headless `peerExtensionSdk` (`authenticate`/`onMetadataMessage`) that the extension `0.6.0` guides (#103, #104) document. This PR closes the release-dependency gap flagged on #104 and documents the rest of what shipped in 0.5.0.

### Version references
- SDK overview + client reference: current npm release `0.4.3` → `0.5.0`; routing note now reads `0.5.x`.
- React Native SDK: current npm release is `0.4.1` (still wraps `@zkp2p/sdk@0.4.3` — noted as-is).

### 0.5.0 requirement called out where it matters
`0.4.x`'s `peerExtensionSdk` only exposes the **removed** deeplink API, so integrators on the new flow must be on `0.5.0+`. Added that requirement to: the onramp guide prerequisites, the deprecation banner, the pre-0.6.0 migration section, the Build Your Own Extension SDK reference, and the downloadable LLM prompt.

### New 0.5.0 API surface documented (per the release notes, verified against the published tarball types)
- **`uploadSellerCredentialBundle()`** — new Client Reference entry; the page-side half of the extension Seller Autopilot capture flow (registers the payee and stores an already-encrypted bundle).
- **`onAttestationComplete`** added to `fulfillIntent()` callbacks.
- **`takerAmountNetFees`** noted on the indexer fulfillment queries (`getFulfilledIntentEvents`, `getIntentFulfillmentAmounts`).

## Reviewer notes
- Engines/peer deps unchanged in 0.5.0 (`node >= 22`, `viem ^2.37.3`) — existing runtime notes stay accurate.
- One adjacent observation, not addressed here: the React Native page's API docs were written against the `0.2.3` line; npm is now at `0.4.1`. If `0.4.x` changed RN APIs beyond the version number, that page needs its own pass.
- `yarn build` passes with `onBrokenLinks: 'throw'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)